### PR TITLE
Add bilingual docstrings and enforce style

### DIFF
--- a/sampo/backend/multiproc.py
+++ b/sampo/backend/multiproc.py
@@ -1,3 +1,8 @@
+"""Multiprocessing backend for chromosome evaluation.
+
+Многопроцессорный бэкенд для оценки хромосом.
+"""
+
 import math
 from typing import Callable
 
@@ -7,17 +12,34 @@ from random import Random
 
 import pathos.multiprocessing
 
-from sampo.api.genetic_api import ChromosomeType, FitnessFunction, ScheduleGenerationScheme
+from sampo.api.genetic_api import (
+    ChromosomeType,
+    FitnessFunction,
+    ScheduleGenerationScheme,
+)
 from sampo.backend import T, R
 from sampo.backend.default import DefaultComputationalBackend
 from sampo.scheduler.genetic.operators import Individual
-from sampo.scheduler.genetic.utils import create_toolbox_using_cached_chromosomes, init_chromosomes_f
+from sampo.scheduler.genetic.utils import (
+    create_toolbox_using_cached_chromosomes,
+    init_chromosomes_f,
+)
 from sampo.scheduler.heft import HEFTScheduler, HEFTBetweenScheduler
 from sampo.scheduler.resource import AverageReqResourceOptimizer
-from sampo.scheduler.resources_in_time import AverageBinarySearchResourceOptimizingScheduler
+from sampo.scheduler.resources_in_time import (
+    AverageBinarySearchResourceOptimizingScheduler,
+)
 from sampo.scheduler.topological.base import RandomizedTopologicalScheduler
-from sampo.schemas import WorkGraph, Contractor, LandscapeConfiguration, Time, WorkTimeEstimator, Schedule, GraphNode, \
-    NoSufficientContractorError
+from sampo.schemas import (
+    WorkGraph,
+    Contractor,
+    LandscapeConfiguration,
+    Time,
+    WorkTimeEstimator,
+    Schedule,
+    GraphNode,
+    NoSufficientContractorError,
+)
 from sampo.schemas.schedule_spec import ScheduleSpec
 from sampo.schemas.time_estimator import DefaultWorkEstimator
 
@@ -40,8 +62,54 @@ def scheduler_info_initializer(wg: WorkGraph,
                                sgs_type: ScheduleGenerationScheme,
                                only_lft_initialization: bool,
                                is_multiobjective: bool):
-    global g_wg, g_contractors, g_landscape, g_spec, g_toolbox, g_work_estimator, g_deadline, g_rand, g_weights, \
-        g_sgs_type, g_only_lft_initialization, g_is_multiobjective
+    """Initialize global data for child processes.
+
+    Инициализирует глобальные данные для дочерних процессов.
+
+    Args:
+        wg (WorkGraph): Work graph to schedule.
+            Граф работ для планирования.
+        contractors (list[Contractor]): Available contractors.
+            Доступные подрядчики.
+        landscape (LandscapeConfiguration): Landscape configuration.
+            Конфигурация ландшафта.
+        spec (ScheduleSpec): Scheduling specification.
+            Спецификация планирования.
+        selection_size (int): Size of population selection.
+            Размер выборки популяции.
+        mutate_order (float): Probability of order mutation.
+            Вероятность мутации порядка.
+        mutate_resources (float): Probability of resource mutation.
+            Вероятность мутации ресурсов.
+        mutate_zones (float): Probability of zone mutation.
+            Вероятность мутации зон.
+        deadline (Time | None): Scheduling deadline.
+            Дедлайн планирования.
+        weights (list[int] | None): Weights for chromosome types.
+            Веса типов хромосом.
+        init_chromosomes (dict[str, tuple[ChromosomeType, float, ScheduleSpec]]):
+            Cached initial chromosomes.
+            Кэш начальных хромосом.
+        assigned_parent_time (Time): Parent schedule time.
+            Время родительского расписания.
+        fitness_weights (tuple[int | float, ...]): Fitness weights.
+            Веса функции приспособленности.
+        rand (Random | None): Random generator.
+            Генератор случайных чисел.
+        work_estimator_recreate_params (tuple | None): Params to recreate
+            estimator.
+            Параметры для пересоздания оценщика.
+        sgs_type (ScheduleGenerationScheme): Schedule generation scheme.
+            Схема генерации расписания.
+        only_lft_initialization (bool): Use only LFT initialization.
+            Использовать только LFT инициализацию.
+        is_multiobjective (bool): Multiobjective optimization flag.
+            Флаг многокритериальной оптимизации.
+    """
+
+    global g_wg, g_contractors, g_landscape, g_spec, g_toolbox, g_work_estimator, \
+        g_deadline, g_rand, g_weights, g_sgs_type, g_only_lft_initialization, \
+        g_is_multiobjective
 
     g_wg = wg
     g_contractors = contractors
@@ -78,124 +146,297 @@ def scheduler_info_initializer(wg: WorkGraph,
 
 
 class MultiprocessingComputationalBackend(DefaultComputationalBackend):
+    """Backend that computes chromosomes in parallel.
+
+    Бэкенд, вычисляющий хромосомы параллельно.
+    """
 
     def __init__(self, n_cpus: int):
+        """Set up the backend.
+
+        Настраивает бэкенд.
+
+        Args:
+            n_cpus (int): Number of worker CPUs.
+                Количество рабочих CPU.
+        """
+
         self._n_cpus = n_cpus
         self._init_chromosomes = None
         self._pool = None
         super().__init__()
 
     def map(self, action: Callable[[T], R], values: list[T]) -> list[R]:
+        """Apply function to values via pool.
+
+        Применяет функцию к значениям через пул.
+
+        Args:
+            action (Callable[[T], R]): Function to execute.
+                Функция для выполнения.
+            values (list[T]): Values to process.
+                Обрабатываемые значения.
+
+        Returns:
+            list[R]: Results of execution.
+                Результаты выполнения.
+        """
+
         return self._pool.map(action, values)
 
     def _ensure_pool_created(self):
+        """Create multiprocessing pool if absent.
+
+        Создает пул процессов при отсутствии.
+        """
+
         if self._pool is not None:
             return
-        self._pool = pathos.multiprocessing.Pool(self._n_cpus,
-                                                 initializer=scheduler_info_initializer,
-                                                 initargs=(self._wg,
-                                                           self._contractors,
-                                                           self._landscape,
-                                                           self._spec,
-                                                           self._selection_size,
-                                                           self._mutate_order,
-                                                           self._mutate_resources,
-                                                           self._mutate_zones,
-                                                           self._deadline,
-                                                           self._weights,
-                                                           self._init_chromosomes,
-                                                           self._assigned_parent_time,
-                                                           self._fitness_weights,
-                                                           self._rand,
-                                                           self._work_estimator.get_recreate_info(),
-                                                           self._sgs_type,
-                                                           self._only_lft_initialization,
-                                                           self._is_multiobjective))
+        self._pool = pathos.multiprocessing.Pool(
+            self._n_cpus,
+            initializer=scheduler_info_initializer,
+            initargs=(
+                self._wg,
+                self._contractors,
+                self._landscape,
+                self._spec,
+                self._selection_size,
+                self._mutate_order,
+                self._mutate_resources,
+                self._mutate_zones,
+                self._deadline,
+                self._weights,
+                self._init_chromosomes,
+                self._assigned_parent_time,
+                self._fitness_weights,
+                self._rand,
+                self._work_estimator.get_recreate_info(),
+                self._sgs_type,
+                self._only_lft_initialization,
+                self._is_multiobjective,
+            ),
+        )
 
-    def cache_scheduler_info(self,
-                             wg: WorkGraph,
-                             contractors: list[Contractor],
-                             landscape: LandscapeConfiguration = LandscapeConfiguration(),
-                             spec: ScheduleSpec = ScheduleSpec(),
-                             rand: Random | None = None,
-                             work_estimator: WorkTimeEstimator = DefaultWorkEstimator()):
-        super().cache_scheduler_info(wg, contractors, landscape, spec, rand, work_estimator)
+    def cache_scheduler_info(
+        self,
+        wg: WorkGraph,
+        contractors: list[Contractor],
+        landscape: LandscapeConfiguration = LandscapeConfiguration(),
+        spec: ScheduleSpec = ScheduleSpec(),
+        rand: Random | None = None,
+        work_estimator: WorkTimeEstimator = DefaultWorkEstimator(),
+    ):
+        """Store scheduler info and reset pool.
+
+        Сохраняет информацию планировщика и сбрасывает пул.
+
+        Args:
+            wg (WorkGraph): Work graph.
+                Граф работ.
+            contractors (list[Contractor]): Contractors list.
+                Список подрядчиков.
+            landscape (LandscapeConfiguration): Landscape configuration.
+                Конфигурация ландшафта.
+            spec (ScheduleSpec): Scheduling specification.
+                Спецификация планирования.
+            rand (Random | None): Random generator.
+                Генератор случайных чисел.
+            work_estimator (WorkTimeEstimator): Work time estimator.
+                Оценщик времени выполнения.
+        """
+
+        super().cache_scheduler_info(
+            wg, contractors, landscape, spec, rand, work_estimator
+        )
         self._pool = None
 
-    def cache_genetic_info(self,
-                           population_size: int = 50,
-                           mutate_order: float = 0.1,
-                           mutate_resources: float = 0.05,
-                           mutate_zones: float = 0.05,
-                           deadline: Time | None = None,
-                           weights: list[int] | None = None,
-                           init_schedules: dict[
-                               str, tuple[Schedule, list[GraphNode] | None, ScheduleSpec, float]] = None,
-                           assigned_parent_time: Time = Time(0),
-                           fitness_weights: tuple[int | float, ...] = None,
-                           sgs_type: ScheduleGenerationScheme = ScheduleGenerationScheme.Parallel,
-                           only_lft_initialization: bool = False,
-                           is_multiobjective: bool = False):
-        super().cache_genetic_info(population_size, mutate_order, mutate_resources, mutate_zones, deadline,
-                                   weights, init_schedules, assigned_parent_time, fitness_weights, sgs_type,
-                                   only_lft_initialization, is_multiobjective)
+    def cache_genetic_info(
+        self,
+        population_size: int = 50,
+        mutate_order: float = 0.1,
+        mutate_resources: float = 0.05,
+        mutate_zones: float = 0.05,
+        deadline: Time | None = None,
+        weights: list[int] | None = None,
+        init_schedules: dict[
+            str, tuple[Schedule, list[GraphNode] | None, ScheduleSpec, float]
+        ] = None,
+        assigned_parent_time: Time = Time(0),
+        fitness_weights: tuple[int | float, ...] = None,
+        sgs_type: ScheduleGenerationScheme = ScheduleGenerationScheme.Parallel,
+        only_lft_initialization: bool = False,
+        is_multiobjective: bool = False,
+    ):
+        """Store genetic algorithm parameters.
+
+        Сохраняет параметры генетического алгоритма.
+
+        Args:
+            population_size (int): Population size.
+                Размер популяции.
+            mutate_order (float): Probability of order mutation.
+                Вероятность мутации порядка.
+            mutate_resources (float): Probability of resource mutation.
+                Вероятность мутации ресурсов.
+            mutate_zones (float): Probability of zone mutation.
+                Вероятность мутации зон.
+            deadline (Time | None): Scheduling deadline.
+                Дедлайн планирования.
+            weights (list[int] | None): Importance weights.
+                Веса значимости.
+            init_schedules (dict[str, tuple[Schedule, list[GraphNode] | None,
+                                           ScheduleSpec, float]] | None):
+                Initial schedules.
+                Начальные расписания.
+            assigned_parent_time (Time): Parent schedule time.
+                Время родительского расписания.
+            fitness_weights (tuple[int | float, ...] | None): Fitness weights.
+                Веса функции приспособленности.
+            sgs_type (ScheduleGenerationScheme): Generation scheme.
+                Схема генерации расписания.
+            only_lft_initialization (bool): Use only LFT initialization.
+                Использовать только LFT инициализацию.
+            is_multiobjective (bool): Multiobjective optimization flag.
+                Флаг многокритериальной оптимизации.
+        """
+
+        super().cache_genetic_info(
+            population_size,
+            mutate_order,
+            mutate_resources,
+            mutate_zones,
+            deadline,
+            weights,
+            init_schedules,
+            assigned_parent_time,
+            fitness_weights,
+            sgs_type,
+            only_lft_initialization,
+            is_multiobjective,
+        )
         if init_schedules:
-            self._init_chromosomes = init_chromosomes_f(self._wg, self._contractors, init_schedules,
-                                                  self._landscape)
+            self._init_chromosomes = init_chromosomes_f(
+                self._wg, self._contractors, init_schedules, self._landscape
+            )
         else:
             self._init_chromosomes = []
         self._pool = None
 
-    def compute_chromosomes(self, fitness: FitnessFunction, chromosomes: list[ChromosomeType]) -> list[float]:
+    def compute_chromosomes(
+        self,
+        fitness: FitnessFunction,
+        chromosomes: list[ChromosomeType],
+    ) -> list[float]:
+        """Evaluate chromosomes using the pool.
+
+        Оценивает хромосомы с использованием пула.
+
+        Args:
+            fitness (FitnessFunction): Fitness function.
+                Функция приспособленности.
+            chromosomes (list[ChromosomeType]): Chromosomes to evaluate.
+                Хромосомы для оценки.
+
+        Returns:
+            list[float]: Fitness values.
+                Значения приспособленности.
+        """
+
         self._ensure_pool_created()
 
         def mapper(chromosome):
-            return fitness.evaluate(chromosome, g_toolbox.evaluate_chromosome)
+            return fitness.evaluate(
+                chromosome, g_toolbox.evaluate_chromosome
+            )
 
         return self.map(mapper, chromosomes)
 
     def generate_first_population(self, size_population: int) -> list[Individual]:
+        """Generate the initial population in parallel.
+
+        Генерирует начальную популяцию параллельно.
+
+        Args:
+            size_population (int): Number of individuals.
+                Количество индивидуумов.
+
+        Returns:
+            list[Individual]: Initial population.
+                Начальная популяция.
+        """
+
         self._ensure_toolbox_created()
         self._ensure_pool_created()
 
         def mapper(key: str):
             def randomized_init():
-                schedule, _, _, order = RandomizedTopologicalScheduler(g_work_estimator, int(g_rand.random() * 1000000)) \
-                    .schedule_with_cache(g_wg, g_contractors, landscape=g_landscape)[0]
+                schedule, _, _, order = RandomizedTopologicalScheduler(
+                    g_work_estimator, int(g_rand.random() * 1000000)
+                ).schedule_with_cache(g_wg, g_contractors, landscape=g_landscape)[
+                    0
+                ]
                 return schedule, order, g_spec
 
-            def init_k_schedule(scheduler_class, k) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
+            def init_k_schedule(
+                scheduler_class, k
+            ) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
                 try:
-                    schedule, _, _, node_order = (scheduler_class(work_estimator=g_work_estimator,
-                                                                  resource_optimizer=AverageReqResourceOptimizer(k))
-                                                  .schedule_with_cache(g_wg, g_contractors, g_spec,
-                                                                       landscape=g_landscape))[0]
+                    schedule, _, _, node_order = (
+                        scheduler_class(
+                            work_estimator=g_work_estimator,
+                            resource_optimizer=AverageReqResourceOptimizer(k),
+                        ).schedule_with_cache(
+                            g_wg, g_contractors, g_spec, landscape=g_landscape
+                        )
+                    )[0]
                     return schedule, node_order[::-1], g_spec
                 except NoSufficientContractorError:
                     return None, None, None
 
             if g_deadline is None:
-                def init_schedule(scheduler_class) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
+                def init_schedule(
+                    scheduler_class,
+                ) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
                     try:
-                        schedule, _, _, node_order = (scheduler_class(work_estimator=g_work_estimator)
-                                                      .schedule_with_cache(g_wg, g_contractors, g_spec,
-                                                                           landscape=g_landscape))[0]
+                        schedule, _, _, node_order = (
+                            scheduler_class(work_estimator=g_work_estimator)
+                            .schedule_with_cache(
+                                g_wg,
+                                g_contractors,
+                                g_spec,
+                                landscape=g_landscape,
+                            )
+                        )[0]
                         return schedule, node_order[::-1], g_spec
                     except NoSufficientContractorError:
                         return None, None, None
 
             else:
-                def init_schedule(scheduler_class) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
+                def init_schedule(
+                    scheduler_class,
+                ) -> tuple[Schedule | None, list[GraphNode] | None, ScheduleSpec | None]:
                     try:
-                        (schedule, _, _, node_order), modified_spec = AverageBinarySearchResourceOptimizingScheduler(
-                            scheduler_class(work_estimator=g_work_estimator)
-                        ).schedule_with_cache(g_wg, g_contractors, g_deadline, g_spec, landscape=g_landscape)
+                        (schedule, _, _, node_order), modified_spec = (
+                            AverageBinarySearchResourceOptimizingScheduler(
+                                scheduler_class(work_estimator=g_work_estimator)
+                            ).schedule_with_cache(
+                                g_wg,
+                                g_contractors,
+                                g_deadline,
+                                g_spec,
+                                landscape=g_landscape,
+                            )
+                        )
                         return schedule, node_order[::-1], modified_spec
                     except NoSufficientContractorError:
                         return None, None, None
 
-            def convert(schedule: Schedule, priority_list: list[GraphNode], spec: ScheduleSpec):
-                return g_toolbox.schedule_to_chromosome(schedule=schedule, spec=spec, order=priority_list)
+            def convert(
+                schedule: Schedule, priority_list: list[GraphNode], spec: ScheduleSpec
+            ):
+                return g_toolbox.schedule_to_chromosome(
+                    schedule=schedule, spec=spec, order=priority_list
+                )
 
             match key:
                 case 'heft_end':

--- a/sampo/generator/base.py
+++ b/sampo/generator/base.py
@@ -1,3 +1,8 @@
+"""Helpers for generating synthetic project data.
+
+Вспомогательные функции для генерации синтетических данных проекта.
+"""
+
 from random import Random
 
 from sampo.generator import SyntheticGraphType
@@ -10,81 +15,156 @@ from sampo.schemas.graph import WorkGraph
 
 
 class SimpleSynthetic:
-    """
-    Designed to simplify the use of the synthetic data generator.
+    """Simplified interface for synthetic data generation.
+
+    Упрощенный интерфейс для генерации синтетических данных.
     """
 
     def __init__(self, rand: int | Random | None = None) -> None:
+        """Create generator with optional random seed.
+
+        Создает генератор с необязательным источником случайности.
+
+        Args:
+            rand (int | Random | None): Seed or random generator.
+                Зерно или генератор случайных чисел.
+        """
+
         if isinstance(rand, Random):
             self._rand = rand
         else:
             self._rand = Random(rand)
 
     def small_work_graph(self, cluster_name: str | None = 'C1') -> WorkGraph:
-        """
-        Creates a small graph of works consisting of 30-50 vertices;
+        """Create small work graph with 30-50 vertices.
 
-        :param cluster_name: str - the first cluster name
-        :return:
-            work_graph: WorkGraph - work graph where count of vertex between 30 and 50
+        Создает небольшой граф работ из 30-50 вершин.
+
+        Args:
+            cluster_name (str | None): Name of the first cluster.
+                Имя первого кластера.
+
+        Returns:
+            WorkGraph: Generated work graph.
+                Сгенерированный граф работ.
         """
+
         return get_small_graph(cluster_name, self._rand)
 
-    def work_graph(self, mode: SyntheticGraphType | None = SyntheticGraphType.GENERAL,
-                   cluster_counts: int | None = 0,
-                   bottom_border: int | None = 0,
-                   top_border: int | None = 0) -> WorkGraph:
-        """
-        Invokes a graph of the given type if at least one positive value of
-            cluster_counts, bottom_border or top_border is given;
+    def work_graph(
+        self,
+        mode: SyntheticGraphType | None = SyntheticGraphType.GENERAL,
+        cluster_counts: int | None = 0,
+        bottom_border: int | None = 0,
+        top_border: int | None = 0,
+    ) -> WorkGraph:
+        """Generate work graph of the chosen type.
 
-        :param mode: str - 'general' or 'sequence' or 'parallel - the type of the returned graph
-        :param cluster_counts: Optional[int] - Number of clusters for the graph
-        :param bottom_border: Optional[int] - bottom border for number of works for the graph
-        :param top_border: Optional[int] - top border for number of works for the graph
-        :return:
-            work_graph: WorkGraph - the desired work graph
+        Генерирует граф работ выбранного типа.
+
+        Args:
+            mode (SyntheticGraphType | None): Graph type.
+                Тип графа.
+            cluster_counts (int | None): Number of clusters.
+                Количество кластеров.
+            bottom_border (int | None): Lower bound for works.
+                Нижняя граница работ.
+            top_border (int | None): Upper bound for works.
+                Верхняя граница работ.
+
+        Returns:
+            WorkGraph: Generated work graph.
+                Сгенерированный граф работ.
         """
-        return get_graph(mode=mode, cluster_counts=cluster_counts, bottom_border=bottom_border, top_border=top_border,
-                         rand=self._rand)
+
+        return get_graph(
+            mode=mode,
+            cluster_counts=cluster_counts,
+            bottom_border=bottom_border,
+            top_border=top_border,
+            rand=self._rand,
+        )
 
     def contractor(self, pack_worker_count: float):
-        """
-        Generates a contractor by pack_worker_count and from sampo.generator.environment.contractor.get_contractor
-        with default optional parameters
+        """Generate contractor with default parameters.
 
-        :param pack_worker_count: The number of resource sets
-        :return: the contractor
+        Генерирует подрядчика с параметрами по умолчанию.
+
+        Args:
+            pack_worker_count (float): Number of resource sets.
+                Количество наборов ресурсов.
+
+        Returns:
+            Contractor: Generated contractor.
+                Сгенерированный подрядчик.
         """
+
         return get_contractor(pack_worker_count, rand=self._rand)
 
-    def advanced_work_graph(self, works_count_top_border: int, uniq_works: int, uniq_resources: int):
-        """
-        Invokes a graph of the given type for given works_count_top_border,
-        expands the number of unique resources and job titles, if possible
+    def advanced_work_graph(
+        self, works_count_top_border: int, uniq_works: int, uniq_resources: int
+    ) -> WorkGraph:
+        """Generate graph and extend names and resources.
 
-        :param uniq_resources: Number of unique resources
-        :param uniq_works: Number of unique work names
-        :param works_count_top_border: Optional[int] - top border for number of works for the graph
+        Генерирует граф и расширяет названия и ресурсы.
 
-        :return: the desired work graph
+        Args:
+            works_count_top_border (int): Upper bound for work count.
+                Верхняя граница числа работ.
+            uniq_works (int): Number of unique work names.
+                Количество уникальных названий работ.
+            uniq_resources (int): Number of unique resources.
+                Количество уникальных ресурсов.
+
+        Returns:
+            WorkGraph: Generated work graph.
+                Сгенерированный граф работ.
         """
+
         wg = self.work_graph(top_border=works_count_top_border)
         wg = extend_names(uniq_works, wg, self._rand)
         wg = extend_resources(uniq_resources, wg, self._rand)
         return wg
 
-    def set_materials_for_wg(self, wg: WorkGraph, materials_name: list[str] = None, bottom_border: int = None,
-                             top_border: int = None) -> WorkGraph:
+    def set_materials_for_wg(
+        self,
+        wg: WorkGraph,
+        materials_name: list[str] = None,
+        bottom_border: int = None,
+        top_border: int = None,
+    ) -> WorkGraph:
+        """Assign materials to work graph nodes.
+
+        Назначает материалы узлам графа работ.
+
+        Args:
+            wg (WorkGraph): Work graph to modify.
+                Граф работ для изменения.
+            materials_name (list[str] | None): Available material names.
+                Доступные названия материалов.
+            bottom_border (int | None): Minimal kinds per node.
+                Минимальное число видов на узел.
+            top_border (int | None): Maximal kinds per node.
+                Максимальное число видов на узел.
+
+        Returns:
+            WorkGraph: Work graph with materials.
+                Граф работ с материалами.
+
+        Raises:
+            ValueError: Borders exceed materials list.
+                Границы превышают список материалов.
         """
-        Sets the materials for nodes of given work graph
-        :param top_border: the top border for the number of material kinds in each node (except service nodes)
-        :param bottom_border: the bottom border for the number of material kinds in each node (except service nodes)
-        :param materials_name: a list of material names, that can be sent
-        :return: work graph with materials
-        """
+
         if materials_name is None:
-            materials_name = ['stone', 'brick', 'sand', 'rubble', 'concrete', 'metal']
+            materials_name = [
+                'stone',
+                'brick',
+                'sand',
+                'rubble',
+                'concrete',
+                'metal',
+            ]
             bottom_border = 2
             top_border = 6
         else:
@@ -98,15 +178,33 @@ class SimpleSynthetic:
 
         for node in wg.nodes:
             if not node.work_unit.is_service_unit:
-                work_materials = list(set(self._rand.choices(materials_name, k=self._rand.randint(bottom_border, top_border))))
-                node.work_unit.material_reqs = [MaterialReq(name, self._rand.randint(52, 345), name) for name in
-                                                work_materials]
+                work_materials = list(
+                    set(
+                        self._rand.choices(
+                            materials_name,
+                            k=self._rand.randint(bottom_border, top_border),
+                        )
+                    )
+                )
+                node.work_unit.material_reqs = [
+                    MaterialReq(name, self._rand.randint(52, 345), name)
+                    for name in work_materials
+                ]
 
         return wg
 
     def synthetic_landscape(self, wg: WorkGraph) -> LandscapeConfiguration:
+        """Generate landscape for the given work graph.
+
+        Генерирует ландшафт для заданного графа работ.
+
+        Args:
+            wg (WorkGraph): Work graph.
+                Граф работ.
+
+        Returns:
+            LandscapeConfiguration: Generated landscape.
+                Сгенерированный ландшафт.
         """
-        Generates a landscape by work graph
-        :return: LandscapeConfiguration
-        """
+
         return get_landscape_by_wg(wg, self._rand)

--- a/sampo/generator/config/worker_req.py
+++ b/sampo/generator/config/worker_req.py
@@ -1,55 +1,99 @@
+"""Utilities for scaling worker requirements.
+
+Утилиты для масштабирования требований к рабочим.
+"""
+
 from sampo.schemas.requirements import WorkerReq
 from sampo.schemas.time import Time
 
 
-def scale_reqs(req_list: list[WorkerReq], scalar: float, new_name: str | None = None) -> list[WorkerReq]:
-    """
-    Multiplies each of the requirements of their list, scaling the maximum number of resources and volume
+def scale_reqs(
+    req_list: list[WorkerReq], scalar: float, new_name: str | None = None
+) -> list[WorkerReq]:
+    """Scale requirements by scalar.
 
-    :param req_list: list of resource requirements
-    :param scalar: scalar to which the requirements are applied
-    :param new_name: A new name for the requirements
-    :return: scaled requirements
+    Масштабирует требования по коэффициенту.
+
+    Args:
+        req_list (list[WorkerReq]): Requirements to scale.
+            Требования для масштабирования.
+        scalar (float): Scaling factor.
+            Коэффициент масштабирования.
+        new_name (str | None): Optional new name.
+            Необязательное новое имя.
+
+    Returns:
+        list[WorkerReq]: Scaled requirements.
+            Масштабированные требования.
     """
+
     return [work_req.scale_all(scalar, new_name) for work_req in req_list]
 
 
-def mul_volume_reqs(req_list: list[WorkerReq], scalar: float, new_name: str | None = None) -> list[WorkerReq]:
-    """
-    Multiplies each of the requirements of their list, scaling only the volume
+def mul_volume_reqs(
+    req_list: list[WorkerReq], scalar: float, new_name: str | None = None
+) -> list[WorkerReq]:
+    """Scale only volume of requirements.
 
-    :param req_list: list of resource requirements
-    :param scalar: scalar to which the requirements are applied
-    :param new_name: A new name for the requirements
-    :return: scaled requirements
-        """
+    Масштабирует только объём требований.
+
+    Args:
+        req_list (list[WorkerReq]): Requirements to scale.
+            Требования для масштабирования.
+        scalar (float): Scaling factor.
+            Коэффициент масштабирования.
+        new_name (str | None): Optional new name.
+            Необязательное новое имя.
+
+    Returns:
+        list[WorkerReq]: Scaled requirements.
+            Масштабированные требования.
+    """
+
     return [work_req.scale_volume(scalar, new_name) for work_req in req_list]
 
 
-def get_borehole_volume(borehole_count: int, base: (float, float)) -> float:
-    """
-    Function to calculate the scalar for objects depending on the number of boreholes
+def get_borehole_volume(borehole_count: int, base: tuple[float, float]) -> float:
+    """Compute volume multiplier based on boreholes.
 
-    :param borehole_count: number of boreholes on the site
-    :param base:
-        base[0] part of the volume independent of the number of boreholes,
-        base[1] part of the volume dependent on the number of boreholes
-    :return: returns a scalar to calculate the requirements
+    Вычисляет множитель объёма в зависимости от буровых.
+
+    Args:
+        borehole_count (int): Number of boreholes.
+            Количество буровых.
+        base (tuple[float, float]): Base volumes independent and dependent on
+            boreholes.
+            Базовые объёмы, независимые и зависящие от буровых.
+
+    Returns:
+        float: Volume multiplier.
+            Множитель объёма.
     """
+
     return base[0] + base[1] * borehole_count
 
 
-def mul_borehole_volume(req_list: list[WorkerReq], borehole_count: int, base: (float, float)) -> list[WorkerReq]:
-    """
-    Function for scaling resource requirements for works dependent on the number of boreholes
+def mul_borehole_volume(
+    req_list: list[WorkerReq], borehole_count: int, base: tuple[float, float]
+) -> list[WorkerReq]:
+    """Scale requirements by borehole count.
 
-    :param req_list: list of resource requirements
-    :param borehole_count: number of boreholes on the site
-    :param base:
-        base[0] part of the volume independent of the number of boreholes,
-        base[1] part of the volume dependent on the number of boreholes
-    :return: scaled requirements
+    Масштабирует требования по числу буровых.
+
+    Args:
+        req_list (list[WorkerReq]): Requirements to scale.
+            Требования для масштабирования.
+        borehole_count (int): Number of boreholes.
+            Количество буровых.
+        base (tuple[float, float]): Base volumes independent and dependent on
+            boreholes.
+            Базовые объёмы, независимые и зависящие от буровых.
+
+    Returns:
+        list[WorkerReq]: Scaled requirements.
+            Масштабированные требования.
     """
+
     return mul_volume_reqs(req_list, get_borehole_volume(borehole_count, base))
 
 

--- a/sampo/generator/environment/landscape.py
+++ b/sampo/generator/environment/landscape.py
@@ -1,3 +1,8 @@
+"""Landscape generation utilities.
+
+Утилиты для генерации ландшафта.
+"""
+
 import math
 import random
 import uuid
@@ -8,70 +13,98 @@ from sampo.schemas.landscape import ResourceHolder, Vehicle, LandscapeConfigurat
 from sampo.schemas.landscape_graph import LandGraphNode, ResourceStorageUnit, LandGraph
 
 
-def setup_landscape(platforms_info: dict[str, dict[str, int]],
-                    warehouses_info: dict[str, list[dict[str, int], list[tuple[str, dict[str, int]]]]],
-                    roads_info: dict[str, list[tuple[str, float, int]]]) -> LandscapeConfiguration:
+def setup_landscape(
+    platforms_info: dict[str, dict[str, int]],
+    warehouses_info: dict[str, list[dict[str, int], list[tuple[str, dict[str, int]]]]],
+    roads_info: dict[str, list[tuple[str, float, int]]],
+) -> LandscapeConfiguration:
+    """Build landscape configuration from provided data.
+
+    Создает конфигурацию ландшафта из предоставленных данных.
+
+    Args:
+        platforms_info (dict[str, dict[str, int]]): Material counts on
+            platforms.
+            Количество материалов на площадках.
+        warehouses_info (dict[str, list[dict[str, int], list[tuple[str, dict[str, int]]]]]):
+            Warehouses with materials and vehicles.
+            Склады с материалами и техникой.
+        roads_info (dict[str, list[tuple[str, float, int]]]): Road connections
+            between platforms.
+            Дорожные соединения между площадками.
+
+    Returns:
+        LandscapeConfiguration: Configured landscape.
+            Настроенная конфигурация ландшафта.
     """
-    Build landscape configuration based on the provided information with structure as below.
-    Attributes:
-           Platform_info structure:
-                {platform_name:
-                    {material_name: material_count}
-                }
-           Warehouse_info structure:
-                {holder_name:
-                    [
-                        {material_name: material_count},
-                        [(vehicle_name, {vehicle_material_name: vehicle_material_count})]
-                    ]
-                }
-           Roads_info structure:
-                {platform_name:
-                    [(neighbour_name, road_length, road_workload)]
-                }
-    :return: landscape configuration
-    """
+
     name2platform: dict[str, LandGraphNode] = {}
     holders: list[ResourceHolder] = []
     for platform, platform_info in platforms_info.items():
-        node = LandGraphNode(str(uuid.uuid4()), platform, ResourceStorageUnit(
-                {name: count for name, count in platform_info.items()}
-            ))
+        node = LandGraphNode(
+            str(uuid.uuid4()),
+            platform,
+            ResourceStorageUnit({name: count for name, count in platform_info.items()}),
+        )
         name2platform[platform] = node
 
     for holder_name, holder_info in warehouses_info.items():
         materials = holder_info[0]
         vehicles = holder_info[1]
         holder_node = LandGraphNode(
-            str(uuid.uuid4()), holder_name, ResourceStorageUnit(
-                {name: count for name, count in materials.items()}
-            ))
+            str(uuid.uuid4()),
+            holder_name,
+            ResourceStorageUnit({name: count for name, count in materials.items()}),
+        )
         name2platform[holder_name] = holder_node
-        holders.append(ResourceHolder(
-            str(uuid.uuid4()), holder_name,
-            [
-                Vehicle(str(uuid.uuid4()), name, [
-                    Material(str(uuid.uuid4()), mat_name, mat_count)
-                    for mat_name, mat_count in vehicle_mat_info.items()
-                    ])
-                for name, vehicle_mat_info in vehicles
-            ],
-            holder_node
-        ))
+        holders.append(
+            ResourceHolder(
+                str(uuid.uuid4()),
+                holder_name,
+                [
+                    Vehicle(
+                        str(uuid.uuid4()),
+                        name,
+                        [
+                            Material(str(uuid.uuid4()), mat_name, mat_count)
+                            for mat_name, mat_count in vehicle_mat_info.items()
+                        ],
+                    )
+                    for name, vehicle_mat_info in vehicles
+                ],
+                holder_node,
+            )
+        )
 
     for from_node, adj_list in roads_info.items():
-        name2platform[from_node].add_neighbours([(name2platform[node], length, workload)
-                                                 for node, length, workload in adj_list])
+        name2platform[from_node].add_neighbours(
+            [
+                (name2platform[node], length, workload)
+                for node, length, workload in adj_list
+            ]
+        )
 
     platforms: list[LandGraphNode] = list(name2platform.values())
 
-    return LandscapeConfiguration(
-        holders=holders,
-        lg=LandGraph(nodes=platforms)
-    )
+    return LandscapeConfiguration(holders=holders, lg=LandGraph(nodes=platforms))
 
 
 def get_landscape_by_wg(wg: WorkGraph, rnd: random.Random) -> LandscapeConfiguration:
+    """Generate landscape based on a work graph.
+
+    Генерирует ландшафт на основе графа работ.
+
+    Args:
+        wg (WorkGraph): Work graph.
+            Граф работ.
+        rnd (random.Random): Random generator.
+            Генератор случайных чисел.
+
+    Returns:
+        LandscapeConfiguration: Generated landscape.
+            Сгенерированный ландшафт.
+    """
+
     nodes = wg.nodes
     max_materials = defaultdict(int)
 
@@ -87,20 +120,26 @@ def get_landscape_by_wg(wg: WorkGraph, rnd: random.Random) -> LandscapeConfigura
     materials_name = list(max_materials.keys())
 
     for i in range(platforms_number):
-        platforms.append(LandGraphNode(str(uuid.uuid4()), f'platform{i}',
-                                       ResourceStorageUnit(
-                                           {
-                                               # name: rnd.randint(max(max_materials[name], 1),
-                                               #                   2 * max(max_materials[name], 1))
-                                               name: max(max_materials[name], 1)
-                                               for name in materials_name
-                                           }
-                                       )))
+        platforms.append(
+            LandGraphNode(
+                str(uuid.uuid4()),
+                f'platform{i}',
+                ResourceStorageUnit(
+                    {
+                        name: max(max_materials[name], 1)
+                        for name in materials_name
+                    }
+                ),
+            )
+        )
 
     for i, platform in enumerate(platforms):
         if i == platforms_number - 1:
             continue
-        neighbour_platforms = rnd.choices(platforms[i + 1:], k=rnd.randint(1, math.ceil(len(platforms[i + 1:]) / 3)))
+        neighbour_platforms = rnd.choices(
+            platforms[i + 1:],
+            k=rnd.randint(1, math.ceil(len(platforms[i + 1:]) / 3)),
+        )
 
         neighbour_platforms_tmp = neighbour_platforms.copy()
         for neighbour in neighbour_platforms:
@@ -108,17 +147,19 @@ def get_landscape_by_wg(wg: WorkGraph, rnd: random.Random) -> LandscapeConfigura
                 neighbour_platforms_tmp.remove(neighbour)
         neighbour_platforms = neighbour_platforms_tmp
 
-        # neighbour_edges = [(neighbour, rnd.uniform(1.0, 10.0), rnd.randint(wg.vertex_count, wg.vertex_count * 2))
-        #                    for neighbour in neighbour_platforms]
         lengths = [i * 50 for i in range(1, len(neighbour_platforms) + 1)]
-        neighbour_edges = [(neighbour, lengths[i], wg.vertex_count)
-                           for i, neighbour in enumerate(neighbour_platforms)]
+        neighbour_edges = [
+            (neighbour, lengths[i], wg.vertex_count)
+            for i, neighbour in enumerate(neighbour_platforms)
+        ]
         platform.add_neighbours(neighbour_edges)
 
     inseparable_heads = [node for node in nodes if not node.is_inseparable_son()]
 
-    platforms_tmp = ((len(inseparable_heads) // platforms_number) * platforms +
-                     platforms[:len(inseparable_heads) % platforms_number])
+    platforms_tmp = (
+        (len(inseparable_heads) // platforms_number) * platforms
+        + platforms[: len(inseparable_heads) % platforms_number]
+    )
     rnd.shuffle(platforms_tmp)
 
     for node, platform in zip(inseparable_heads, platforms_tmp):
@@ -131,22 +172,31 @@ def get_landscape_by_wg(wg: WorkGraph, rnd: random.Random) -> LandscapeConfigura
     holders = []
 
     sample_materials_for_holders = materials_name * holders_number
-    # random.shuffle(sample_materials_for_holders)
     materials_number = len(materials_name)
 
     for i in range(holders_number):
         if not max_materials:
             materials_name_for_holder = []
         else:
-            materials_name_for_holder = sample_materials_for_holders[i * materials_number: (i + 1) * materials_number]
-        holders_node.append(LandGraphNode(str(uuid.uuid4()), f'holder{i}',
-                                          ResourceStorageUnit(
-                                              {
-                                                  name: max(max_materials[name], 1) * wg.vertex_count
-                                                  for name in materials_name_for_holder
-                                              }
-                                          )))
-        neighbour_platforms = rnd.choices(holders_node[:-1] + platforms, k=rnd.randint(1, len(holders_node[:-1] + platforms)))
+            materials_name_for_holder = sample_materials_for_holders[
+                i * materials_number : (i + 1) * materials_number
+            ]
+        holders_node.append(
+            LandGraphNode(
+                str(uuid.uuid4()),
+                f'holder{i}',
+                ResourceStorageUnit(
+                    {
+                        name: max(max_materials[name], 1) * wg.vertex_count
+                        for name in materials_name_for_holder
+                    }
+                ),
+            )
+        )
+        neighbour_platforms = rnd.choices(
+            holders_node[:-1] + platforms,
+            k=rnd.randint(1, len(holders_node[:-1] + platforms)),
+        )
 
         neighbour_platforms_tmp = neighbour_platforms.copy()
         for neighbour in neighbour_platforms:
@@ -154,22 +204,32 @@ def get_landscape_by_wg(wg: WorkGraph, rnd: random.Random) -> LandscapeConfigura
                 neighbour_platforms_tmp.remove(neighbour)
         neighbour_platforms = neighbour_platforms_tmp
 
-        # neighbour_edges = [(neighbour, rnd.uniform(1.0, 10.0), rnd.randint(wg.vertex_count, wg.vertex_count * 2))
-        #                    for neighbour in neighbour_platforms]
         lengths = [i * 50 for i in range(1, len(neighbour_platforms) + 1)]
-        neighbour_edges = [(neighbour, lengths[i], wg.vertex_count * 2)
-                           for i, neighbour in enumerate(neighbour_platforms)]
+        neighbour_edges = [
+            (neighbour, lengths[i], wg.vertex_count * 2)
+            for i, neighbour in enumerate(neighbour_platforms)
+        ]
         holders_node[-1].add_neighbours(neighbour_edges)
 
-        # vehicles_number = rnd.randint(7, 20)
         vehicles_number = 20
-        holders.append(ResourceHolder(str(uuid.uuid4()), holders_node[-1].name,
-                                      vehicles=[
-                                          Vehicle(str(uuid.uuid4()), f'vehicle{j}',
-                                                  [Material(name, name, count // 2)
-                                                   for name, count in max_materials.items()])
-                                          for j in range(vehicles_number)
-                                      ], node=holders_node[-1]))
+        holders.append(
+            ResourceHolder(
+                str(uuid.uuid4()),
+                holders_node[-1].name,
+                vehicles=[
+                    Vehicle(
+                        str(uuid.uuid4()),
+                        f'vehicle{j}',
+                        [
+                            Material(name, name, count // 2)
+                            for name, count in max_materials.items()
+                        ],
+                    )
+                    for j in range(vehicles_number)
+                ],
+                node=holders_node[-1],
+            )
+        )
 
     lg = LandGraph(nodes=platforms + holders_node)
     return LandscapeConfiguration(holders, lg)


### PR DESCRIPTION
## Summary
- add bilingual module docstrings and Google-style docstrings across generator and backend modules
- reformat imports and lines for PEP8 compliance

## Testing
- `pylint sampo/backend/multiproc.py sampo/generator/base.py sampo/generator/config/worker_req.py sampo/generator/environment/landscape.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e749a1e8832e84b1135498446ca2