### PR TITLE
Add bilingual docstrings for pipelines and setup

### DIFF
--- a/sampo/generator/pipeline/cluster.py
+++ b/sampo/generator/pipeline/cluster.py
@@ -1,9 +1,14 @@
+"""Generate work clusters for synthetic project graphs.
+
+Генерация рабочих кластеров для синтетических графов проектов.
+"""
+
 from random import Random
 
 import sampo.generator.config.gen_counts as gen_c
 import sampo.generator.config.worker_req as wr
 from sampo.generator.config.worker_req import scale_reqs
-from sampo.schemas.graph import GraphNode, EdgeType
+from sampo.schemas.graph import EdgeType, GraphNode
 from sampo.schemas.interval import IntervalUniform
 from sampo.schemas.utils import uuid_str
 from sampo.schemas.works import WorkUnit
@@ -178,18 +183,33 @@ def get_cluster_works(cluster_name: str, pipe_nodes_count: int,
                       pipe_net_count: int, light_masts_count: int, borehole_counts: list[int],
                       roads: dict[str, GraphNode] | None = None,
                       rand: Random | None = None) -> tuple[GraphNode, dict[str, GraphNode], int]:
-    """
-    Creates works on the development of the field on one object, i.e. a group of boreholes
+    """Create works for developing a field cluster.
 
-    :param root_node: The parent node of the work graph for this object
-    :param cluster_name: object name
-    :param pipe_nodes_count: Number of pipeline segments from this field to other fields
-    :param pipe_net_count: Number of pipes connecting boreholes
-    :param light_masts_count: Number of floodlight masts
-    :param borehole_counts: Number of boreholes
-    :param roads: If the object is not connected to the central node, the road to which it is connected, otherwise None
-    :param rand: Number generator with a fixed seed, or None for no fixed seed
-    :return:
+    Создаёт работы для разработки кластера месторождения.
+
+    Args:
+        cluster_name (str): Name of the cluster.
+            Имя кластера.
+        pipe_nodes_count (int): Number of pipeline segments to other fields.
+            Количество участков трубопровода к другим месторождениям.
+        pipe_net_count (int): Number of pipes connecting boreholes.
+            Число труб, соединяющих скважины.
+        light_masts_count (int): Number of floodlight masts.
+            Количество осветительных мачт.
+        borehole_counts (list[int]): Number of boreholes in each group.
+            Количество скважин в каждой группе.
+        roads (dict[str, GraphNode] | None): Roads connecting to the central
+            node, if any.
+            Дороги, соединяющие с центральным узлом, если имеются.
+        rand (Random | None): Random number generator.
+            Генератор случайных чисел.
+
+    Returns:
+        tuple[GraphNode, dict[str, GraphNode], int]:
+        Root node of the cluster, generated roads, and number of created
+            nodes.
+        Корневой узел кластера, созданные дороги и количество
+            сформированных узлов.
     """
     is_slave = roads is not None
     dist_to_parent = None

--- a/sampo/generator/pipeline/project.py
+++ b/sampo/generator/pipeline/project.py
@@ -1,20 +1,37 @@
+"""Utilities for generating synthetic project graphs.
+
+Утилиты для генерации синтетических графов проекта.
+"""
+
 from random import Random
 from typing import Callable
 
-from sampo.generator.config.gen_counts import MIN_GRAPH_COUNTS, ADDITION_CLUSTER_PROBABILITY, GRAPH_COUNTS, \
-    MAX_BOREHOLES_PER_BLOCK, BRANCHING_PROBABILITY
-from sampo.generator.pipeline import SyntheticGraphType, StageType
-from sampo.generator.pipeline.cluster import get_cluster_works, _add_addition_work
+from sampo.generator.config.gen_counts import (
+    ADDITION_CLUSTER_PROBABILITY,
+    BRANCHING_PROBABILITY,
+    GRAPH_COUNTS,
+    MAX_BOREHOLES_PER_BLOCK,
+    MIN_GRAPH_COUNTS,
+)
+from sampo.generator.pipeline import StageType, SyntheticGraphType
+from sampo.generator.pipeline.cluster import _add_addition_work, get_cluster_works
 from sampo.schemas.graph import GraphNode, WorkGraph
 
 
 def get_small_graph(cluster_name: str | None = 'C1', rand: Random | None = None) -> WorkGraph:
-    """
-    Creates a small graph of works consisting of 30-50 vertices
+    """Create a small work graph with 30-50 vertices.
 
-    :param cluster_name: str - the first cluster name
-    :param rand: Optional[Random] - generator of numbers with a given seed or None
-    :return: work_graph: WorkGraph - work graph where count of vertex between 30 and 50
+    Создаёт небольшой граф работ, содержащий 30–50 вершин.
+
+    Args:
+        cluster_name (str | None): Name of the initial cluster.
+            Имя первого кластера.
+        rand (Random | None): Random number generator.
+            Генератор случайных чисел.
+
+    Returns:
+        WorkGraph: Work graph containing between 30 and 50 vertices.
+        WorkGraph: Граф работ, включающий от 30 до 50 вершин.
     """
 
     pipe_nodes_count = MIN_GRAPH_COUNTS['pipe_nodes'].rand_int(rand)
@@ -53,10 +70,15 @@ def _get_cluster_graph(cluster_name: str, pipe_nodes_count: int | None = None,
 
     checkpoints = [c_master]
     if add_addition_cluster or _add_addition_work(addition_cluster_probability, rand):
-        c_slave, _, count_slave = get_cluster_works(cluster_name=cluster_name,
-                                                    pipe_nodes_count=pipe_nodes_count, pipe_net_count=pipe_net_count,
-                                                    light_masts_count=light_masts_count, borehole_counts=borehole_counts,
-                                                    roads=roads, rand=rand)
+        c_slave, _, count_slave = get_cluster_works(
+            cluster_name=cluster_name,
+            pipe_nodes_count=pipe_nodes_count,
+            pipe_net_count=pipe_net_count,
+            light_masts_count=light_masts_count,
+            borehole_counts=borehole_counts,
+            roads=roads,
+            rand=rand,
+        )
         count_nodes += count_slave
         checkpoints.append(c_slave)
     return checkpoints, roads, count_nodes
@@ -70,23 +92,33 @@ def get_graph(mode: SyntheticGraphType | None = SyntheticGraphType.GENERAL,
               bottom_border: int | None = 0,
               top_border: int | None = 0,
               rand: Random | None = None) -> WorkGraph:
-    """
-    Invokes a graph of the given type if at least one positive value of cluster_counts, addition_cluster_probability,
-    bottom_border is given
+    """Generate a synthetic work graph of the specified type.
 
-    :param mode: str - 'general' or 'sequence' or 'parallel - the type of the returned graph
-    :param cluster_name_prefix: str -  cluster name prefix, if the prefix is 'C',
-        the clusters will be called 'C1', 'C2' etc.
-    :param cluster_counts: Optional[int] - Number of clusters for the graph
-    :param branching_probability: Optional[float] - The probability that the node will not be connected to the last
-        cluster, but to any other cluster for the general mode
-    :param addition_cluster_probability: Optional[float] - probability of a slave (example C3_1) cluster
-        to the main cluster
-    :param bottom_border: Optional[int] - bottom border for number of works for the graph
-    :param top_border: Optional[int] - top border for number of works for the graph
-    :param rand: Optional[Random] - generator of numbers with a given seed or None
-    :return:
-        work_graph: WorkGraph - the desired work graph
+    Генерирует синтетический граф работ указанного типа.
+
+    Args:
+        mode (SyntheticGraphType | None): Type of graph to generate.
+            Тип генерируемого графа.
+        cluster_name_prefix (str | None): Prefix used for cluster names.
+            Префикс, используемый для имен кластеров.
+        cluster_counts (int | None): Desired number of clusters in the graph.
+            Требуемое число кластеров в графе.
+        branching_probability (float | None): Probability of connecting a
+            cluster to a non-sequential predecessor.
+            Вероятность соединения кластера с неочередным предшественником.
+        addition_cluster_probability (float | None): Probability of adding a
+            slave cluster.
+            Вероятность добавления подчинённого кластера.
+        bottom_border (int | None): Minimum number of works in the graph.
+            Минимальное количество работ в графе.
+        top_border (int | None): Maximum number of works in the graph.
+            Максимальное количество работ в графе.
+        rand (Random | None): Random number generator.
+            Генератор случайных чисел.
+
+    Returns:
+        WorkGraph: Generated work graph.
+        WorkGraph: Сгенерированный граф работ.
     """
     assert cluster_counts + bottom_border + top_border > 0, 'At least one border param should be specified'
     assert cluster_counts >= 0 and branching_probability >= 0 and top_border >= 0, 'Params should not be negative'

--- a/sampo/native/setup.py
+++ b/sampo/native/setup.py
@@ -1,3 +1,8 @@
+"""Setup tools for native C++ extensions.
+
+Инструменты сборки C++-расширений.
+"""
+
 import os
 import pathlib
 from distutils.core import setup, Extension
@@ -29,23 +34,47 @@ ext_modules = [
 
 
 class BuildFailed(Exception):
-    pass
+    """Raised when C++ extension build fails.
+
+    Возникает при сбое сборки C++-расширения.
+    """
+
 
 class CMakeExtension(Extension):
+    """Minimal CMake-based extension.
 
-    def __init__(self, name):
-        # don't invoke the original build_ext for this special extension
+    Минимальное расширение на основе CMake.
+    """
+
+    def __init__(self, name: str) -> None:
+        """Initialize extension without default build steps.
+
+        Инициализирует расширение без стандартных шагов сборки.
+        """
         super().__init__(name, sources=[])
 
 
 class build_ext(build_ext_orig):
+    """Custom build_ext command using CMake.
 
-    def run(self):
+    Пользовательская команда build_ext с использованием CMake.
+    """
+
+    def run(self) -> None:
+        """Build each extension using CMake before running default build.
+
+        Собирает каждое расширение через CMake перед выполнением стандартной
+        сборки.
+        """
         for ext in self.extensions:
             self.build_cmake(ext)
         super().run()
 
-    def build_cmake(self, ext):
+    def build_cmake(self, ext: Extension) -> None:
+        """Invoke CMake build for a single extension.
+
+        Вызывает сборку CMake для одного расширения.
+        """
         cwd = pathlib.Path().absolute()
 
         # these dirs will be created in build_py, so if you don't have
@@ -58,49 +87,79 @@ class build_ext(build_ext_orig):
         # example of cmake args
         config = 'Release'  # 'Debug' if self.debug else 'Release'
         cmake_args = [
-            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + str(extdir.parent.absolute()),
+            '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY='
+            + str(extdir.parent.absolute()),
             '-DCMAKE_BUILD_TYPE=' + config,
             '-DCMAKE_C_COMPILER=gcc',
-            '-DCMAKE_CXX_COMPILER=g++'
+            '-DCMAKE_CXX_COMPILER=g++',
         ]
 
         # example of build args
         build_args = [
-            '--config', config
+            '--config', config,
             # '--', '-j4'
         ]
 
         os.chdir(str(build_temp))
         self.spawn(['cmake', str(cwd)] + cmake_args)
         if not self.dry_run:
-            self.spawn(['cmake', '--build', '-DCMAKE_CXX_COMPILER=g++', '.'] + build_args)
+            self.spawn(
+                [
+                    'cmake',
+                    '--build',
+                    '-DCMAKE_CXX_COMPILER=g++',
+                    '.',
+                ]
+                + build_args
+            )
         # Troubleshooting: if fail on line above then delete all possible
         # temporary CMake files including "CMakeCache.txt" in top level dir.
         os.chdir(str(cwd))
 
 
 class ExtBuilder(build_ext):
+    """Wrapper that converts build errors to BuildFailed.
 
-    def run(self):
+    Обёртка, преобразующая ошибки сборки в BuildFailed.
+    """
+
+    def run(self) -> None:
+        """Run build and convert missing files into BuildFailed.
+
+        Запускает сборку и преобразует отсутствие файлов в BuildFailed.
+        """
         try:
             build_ext.run(self)
         except (DistutilsPlatformError, FileNotFoundError):
             raise BuildFailed('File not found. Could not compile C extension.')
 
-    def build_extension(self, ext):
+    def build_extension(self, ext: Extension) -> None:
+        """Build single extension with error handling.
+
+        Выполняет сборку одного расширения с обработкой ошибок.
+        """
         try:
             build_ext.build_extension(self, ext)
         except (CCompilerError, DistutilsExecError, DistutilsPlatformError, ValueError):
             raise BuildFailed('Could not compile C extension.')
 
 
-def build(setup_kwargs):
-    """
-    This function is mandatory in order to build the extensions.
+def build(setup_kwargs: dict) -> None:
+    """Prepare keyword arguments for building extensions.
+
+    Обновляет параметры для сборки расширений.
+
+    Args:
+        setup_kwargs (dict): Keyword arguments passed to ``setup``.
+            Аргументы, передаваемые в ``setup``.
     """
     setup_kwargs.update(
-        {"ext_modules": [CMakeExtension(".")], "cmdclass": {"build_ext": build_ext}}
+        {
+            "ext_modules": [CMakeExtension(".")],
+            "cmdclass": {"build_ext": build_ext},
+        }
     )
+
 
 setup(
     name='native',

--- a/sampo/pipeline/default.py
+++ b/sampo/pipeline/default.py
@@ -1,3 +1,10 @@
+"""Default pipelines for scheduling operations.
+
+Стандартные конвейеры для планирования операций.
+"""
+
+from __future__ import annotations
+
 import pandas as pd
 
 from sampo.generator.environment import ContractorGenerationMethod
@@ -23,9 +30,31 @@ from sampo.schemas.time_estimator import WorkTimeEstimator, DefaultWorkEstimator
 from sampo.structurator import graph_restructuring
 from sampo.userinput.parser.csv_parser import CSVParser
 from sampo.utilities.name_mapper import NameMapper, read_json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from sampo.utilities.visualization import Visualization
 
 
-def contractors_can_perform_work_graph(contractors: list[Contractor], wg: WorkGraph) -> bool:
+def contractors_can_perform_work_graph(
+    contractors: list[Contractor],
+    wg: WorkGraph,
+) -> bool:
+    """Check if each work node has an eligible contractor.
+
+    Проверяет, имеет ли каждый узел работ подходящего подрядчика.
+
+    Args:
+        contractors (list[Contractor]): Available contractors.
+            Доступные подрядчики.
+        wg (WorkGraph): Work graph to evaluate.
+            Граф работ для оценки.
+
+    Returns:
+        bool: True if each node can be performed by at least one contractor.
+        bool: True, если каждый узел может быть выполнен хотя бы одним
+            подрядчиком.
+    """
     is_at_least_one_contractor_can_perform = True
     num_contractors_can_perform_node = 0
 
@@ -49,11 +78,16 @@ def contractors_can_perform_work_graph(contractors: list[Contractor], wg: WorkGr
 
 
 class DefaultInputPipeline(InputPipeline):
-    """
-    Default pipeline, that help to use the framework
+    """Default pipeline simplifying framework usage.
+
+    Стандартный конвейер, упрощающий использование фреймворка.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize pipeline with default components.
+
+        Инициализирует конвейер с компонентами по умолчанию.
+        """
         self._wg: WorkGraph | pd.DataFrame | str | None = None
         self._contractors: list[Contractor] | pd.DataFrame | str | tuple[ContractorGenerationMethod, int] | None \
             = ContractorGenerationMethod.AVG, 1
@@ -80,17 +114,31 @@ class DefaultInputPipeline(InputPipeline):
            sep: str = ',',
            all_connections: bool = False,
            change_connections_info: bool = False) -> 'InputPipeline':
-        """
-        Mandatory argument.
+        """Set work graph for scheduling.
 
-        :param change_base_on_history: whether it is necessary to change project information based on connection history data
-        :param is_wg_has_full_info_about_connections: does the project information contain full details of the works
-        :param wg: the WorkGraph object for scheduling task
-        :param sep: separating character. It's mandatory, if you send the file path with work_info
+        Устанавливает граф работ для планирования.
 
-        ATTENTION!
-            If you send WorkGraph .csv or HistoryData file path, use the same separating character in
-            work_info.csv as in history_data.csv and vice versa.
+        Args:
+            wg (WorkGraph | pd.DataFrame | str): Work graph or path/dataframe.
+                Граф работ либо путь/таблица.
+            change_base_on_history (bool): Modify info using history data.
+                Изменять информацию проекта на основе истории.
+            sep (str): Separator for CSV files.
+                Разделитель для CSV-файлов.
+            all_connections (bool): Whether graph contains all connections.
+                Содержит ли граф всю информацию о связях.
+            change_connections_info (bool): Update connections from history.
+                Обновлять связи из истории.
+
+        Warning:
+            If file paths are provided, use the same separator in
+            ``work_info.csv`` and ``history_data.csv``.
+            При передаче путей используйте одинаковый разделитель в
+            ``work_info.csv`` и ``history_data.csv``.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._wg = wg
         self._all_connections = all_connections
@@ -100,32 +148,50 @@ class DefaultInputPipeline(InputPipeline):
 
     def contractors(self, contractors: list[Contractor] | pd.DataFrame | str | tuple[ContractorGenerationMethod, int]) \
             -> 'InputPipeline':
-        """
-        Mandatory argument.
+        """Set contractors for scheduling.
 
-        :param contractors: the contractors list for scheduling task, or DataFrame with contractor info,
-                            or file with contractor info, of method for contractors generation with
-                            number of contractors to be generated
-        :return: the pipeline object
+        Устанавливает подрядчиков для планирования.
+
+        Args:
+            contractors (list[Contractor] | pd.DataFrame | str | tuple[ContractorGenerationMethod, int]):
+                Contractors list, dataframe, file path, or generation method and count.
+                Список подрядчиков, DataFrame, путь к файлу или метод генерации и количество.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._contractors = contractors
         return self
 
     def landscape(self, landscape_config: LandscapeConfiguration) -> 'InputPipeline':
-        """
-        Set landscape configuration
+        """Set landscape configuration.
 
-        :param landscape_config:
-        :return:
+        Устанавливает конфигурацию ландшафта.
+
+        Args:
+            landscape_config (LandscapeConfiguration): Landscape settings.
+                Настройки ландшафта.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._landscape_config = landscape_config
         return self
 
     def name_mapper(self, name_mapper: NameMapper | str) -> 'InputPipeline':
-        """
-        Set works' name mapper
-        :param name_mapper:
-        :return:
+        """Set works' name mapper.
+
+        Устанавливает преобразователь имён работ.
+
+        Args:
+            name_mapper (NameMapper | str): Mapper object or path to JSON.
+                Объект преобразователя или путь к JSON.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         if isinstance(name_mapper, str):
             name_mapper = read_json(name_mapper)
@@ -133,63 +199,141 @@ class DefaultInputPipeline(InputPipeline):
         return self
 
     def history(self, history: pd.DataFrame | str, sep: str = ';') -> 'InputPipeline':
-        """
-        Set historical data. Mandatory method, if work graph hasn't info about links
-        :param history:
-        :param sep: separating character. It's mandatory, if you send the file path with work_info
+        """Set historical data for link recovery.
 
-        ATTENTION!
-            If you send WorkGraph .csv or HistoryData file path, use the same separating character in
-            work_info.csv as in history_data.csv and vice versa.
+        Устанавливает исторические данные для восстановления связей.
+
+        Args:
+            history (pd.DataFrame | str): History dataframe or path.
+                DataFrame с историей или путь к файлу.
+            sep (str): Separator used in CSV files.
+                Разделитель, применяемый в CSV-файлах.
+
+        Warning:
+            Use the same separator in ``work_info.csv`` and ``history_data.csv``.
+            Используйте одинаковый разделитель в ``work_info.csv`` и ``history_data.csv``.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._history = history
         self.sep_history = sep
         return self
 
     def spec(self, spec: ScheduleSpec) -> 'InputPipeline':
-        """
-        Set specification of schedule
+        """Set schedule specification.
 
-        :param spec:
-        :return:
+        Устанавливает спецификацию расписания.
+
+        Args:
+            spec (ScheduleSpec): Scheduling constraints.
+                Ограничения планирования.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._spec = spec
         return self
 
     def time_shift(self, time: Time) -> 'InputPipeline':
-        """
-        If the schedule should start at a certain time
+        """Assign start time for the schedule.
 
-        :param time:
-        :return:
+        Назначает время начала расписания.
+
+        Args:
+            time (Time): Desired start time.
+                Желаемое время начала.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._assigned_parent_time = time
         return self
 
     def lag_optimize(self, lag_optimize: LagOptimizationStrategy) -> 'InputPipeline':
-        """
-        Mandatory argument. Shows should graph be lag-optimized or not.
-        If not defined, pipeline should search the best variant of this argument in result.
+        """Specify lag optimization strategy.
 
-        :param lag_optimize:
-        :return: the pipeline object
+        Указывает стратегию оптимизации временных разрывов.
+
+        Args:
+            lag_optimize (LagOptimizationStrategy): Selected optimization strategy.
+                Выбранная стратегия оптимизации.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
         """
         self._lag_optimize = lag_optimize
         return self
 
     def work_estimator(self, work_estimator: WorkTimeEstimator) -> 'InputPipeline':
+        """Set work time estimator.
+
+        Устанавливает оценщик времени работ.
+
+        Args:
+            work_estimator (WorkTimeEstimator): Estimator instance.
+                Экземпляр оценщика.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
+        """
         self._work_estimator = work_estimator
         return self
 
     def node_order(self, node_orders: list[list[GraphNode]]) -> 'InputPipeline':
+        """Define custom order for groups of nodes.
+
+        Определяет пользовательский порядок групп узлов.
+
+        Args:
+            node_orders (list[list[GraphNode]]): Ordered node groups.
+                Упорядоченные группы узлов.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
+        """
         self._node_orders = node_orders
         return self
 
     def optimize_local(self, optimizer: OrderLocalOptimizer, area: range) -> 'InputPipeline':
+        """Add local optimizer to the pipeline.
+
+        Добавляет локальный оптимизатор в конвейер.
+
+        Args:
+            optimizer (OrderLocalOptimizer): Optimizer to apply.
+                Применяемый оптимизатор.
+            area (range): Range of nodes affected.
+                Диапазон затрагиваемых узлов.
+
+        Returns:
+            InputPipeline: Pipeline object for chaining.
+            InputPipeline: Объект конвейера для цепочек.
+        """
         self._local_optimize_stack.add(optimizer.optimize, area)
         return self
 
     def schedule(self, scheduler: Scheduler, validate: bool = False) -> 'SchedulePipeline':
+        """Build schedule using provided scheduler.
+
+        Строит расписание с использованием указанного планировщика.
+
+        Args:
+            scheduler (Scheduler): Scheduling algorithm.
+                Алгоритм планирования.
+            validate (bool): Whether to validate resulting schedule.
+                Проверять ли итоговое расписание.
+
+        Returns:
+            SchedulePipeline: Pipeline producing the schedule.
+            SchedulePipeline: Конвейер, формирующий расписание.
+        """
         if isinstance(self._wg, pd.DataFrame) or isinstance(self._wg, str):
             self._wg, self._contractors = \
                 CSVParser.work_graph_and_contractors(
@@ -294,32 +438,93 @@ class DefaultInputPipeline(InputPipeline):
 
 # noinspection PyProtectedMember
 class DefaultSchedulePipeline(SchedulePipeline):
+    """Pipeline for processing generated schedules.
 
-    def __init__(self, s_input: DefaultInputPipeline, wg: WorkGraph, schedules: list[Schedule]):
+    Конвейер для обработки полученных расписаний.
+    """
+
+    def __init__(self, s_input: DefaultInputPipeline, wg: WorkGraph, schedules: list[Schedule]) -> None:
+        """Initialize schedule pipeline.
+
+        Инициализирует конвейер расписаний.
+
+        Args:
+            s_input (DefaultInputPipeline): Source input pipeline.
+                Исходный конвейер ввода.
+            wg (WorkGraph): Work graph used for scheduling.
+                Используемый граф работ.
+            schedules (list[Schedule]): Generated schedules.
+                Список сгенерированных расписаний.
+        """
         self._input = s_input
         self._wg = wg
         self._worker_pool = get_worker_contractor_pool(s_input._contractors)
         self._schedules = schedules
-        self._scheduled_works = [{wg[swork.id]: swork for swork in schedule.to_schedule_work_dict.values()}
-                                 for schedule in schedules]
+        self._scheduled_works = [
+            {wg[swork.id]: swork for swork in schedule.to_schedule_work_dict.values()}
+            for schedule in schedules
+        ]
         self._local_optimize_stack = ApplyQueue()
         self._start_date = None
 
     def optimize_local(self, optimizer: ScheduleLocalOptimizer, area: range) -> 'SchedulePipeline':
-        self._local_optimize_stack.add(optimizer.optimize,
-                                       self._input._contractors, self._input._landscape_config,
-                                       self._input._spec, self._worker_pool, self._input._work_estimator,
-                                       self._input._assigned_parent_time, area)
+        """Add local optimizer for schedule stage.
+
+        Добавляет локальный оптимизатор для стадии расписания.
+
+        Args:
+            optimizer (ScheduleLocalOptimizer): Optimizer to apply.
+                Применяемый оптимизатор.
+            area (range): Range of works affected.
+                Диапазон затрагиваемых работ.
+
+        Returns:
+            SchedulePipeline: Pipeline object for chaining.
+            SchedulePipeline: Объект конвейера для цепочек.
+        """
+        self._local_optimize_stack.add(
+            optimizer.optimize,
+            self._input._contractors,
+            self._input._landscape_config,
+            self._input._spec,
+            self._worker_pool,
+            self._input._work_estimator,
+            self._input._assigned_parent_time,
+            area,
+        )
         return self
 
     def finish(self) -> list[ScheduledProject]:
+        """Finalize scheduling and return projects.
+
+        Завершает планирование и возвращает проекты.
+
+        Returns:
+            list[ScheduledProject]: Final scheduled projects.
+            list[ScheduledProject]: Итоговые запланированные проекты.
+        """
         scheduled_projects = []
         for scheduled_works, node_order in zip(self._scheduled_works, self._input._node_orders):
             processed_sworks = self._local_optimize_stack.apply(scheduled_works, node_order)
             schedule = Schedule.from_scheduled_works(processed_sworks.values(), self._wg)
-            scheduled_projects.append(ScheduledProject(self._input._wg, self._wg, self._input._contractors, schedule))
+            scheduled_projects.append(
+                ScheduledProject(self._input._wg, self._wg, self._input._contractors, schedule)
+            )
         return scheduled_projects
 
-    def visualization(self, start_date: str) -> list['Visualization']:
+    def visualization(self, start_date: str) -> list[Visualization]:
+        """Create visualizations for scheduled projects.
+
+        Создаёт визуализации запланированных проектов.
+
+        Args:
+            start_date (str): Start date for visualization.
+                Дата начала для визуализации.
+
+        Returns:
+            list[Visualization]: Generated visualizations.
+            list[Visualization]: Созданные визуализации.
+        """
         from sampo.utilities.visualization import Visualization
+
         return [Visualization.from_project(project, start_date) for project in self.finish()]


### PR DESCRIPTION
## Summary
- add EN/RU module headers for cluster, project, setup, and default pipeline modules
- document public APIs with bilingual Google-style docstrings
- ensure style compliance and run flake8 and pytest

## Testing
- `flake8 --max-line-length=120 sampo/generator/pipeline/cluster.py sampo/generator/pipeline/project.py sampo/native/setup.py sampo/pipeline/default.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e74a0268832ebfea61e45ab5c860