### PR TITLE
Add bilingual docstrings for structurator modules

### DIFF
--- a/sampo/structurator/__init__.py
+++ b/sampo/structurator/__init__.py
@@ -1,3 +1,8 @@
+"""High-level helpers for structural changes in work graphs.
+
+Высокоуровневые вспомогательные функции для структурных изменений графов работ.
+"""
+
 from sampo.structurator.base import graph_restructuring, STAGE_SEP
 from sampo.structurator.graph_insertion import graph_in_graph_insertion
 from sampo.structurator.light_modifications import work_graph_ids_simplification

--- a/sampo/structurator/delete_graph_node.py
+++ b/sampo/structurator/delete_graph_node.py
@@ -1,16 +1,33 @@
+"""Operations for removing nodes from work graphs.
+
+Операции по удалению узлов из графов работ.
+"""
+
 from sampo.schemas.graph import WorkGraph, GraphNode
 from sampo.structurator.prepare_wg_copy import prepare_work_graph_copy, new_start_finish
 
 
-def delete_graph_node(original_wg: WorkGraph, remove_gn_id: str, change_id: bool = True) -> WorkGraph:
-    """
-    Deletes a task from WorkGraph.
-    If the task consists of several inseparable nodes this function deletes all of those nodes
-    :param original_wg: WorkGraph from which a task is deleted
-    :param remove_gn_id: id of the node, corresponding to the deleted task.
-    If the task consists of several inseparable nodes, this is id of one of them
-    :param change_id: do ids in the new graph need to be changed
-    :return: new WorkGraph with deleted task
+def delete_graph_node(
+    original_wg: WorkGraph, remove_gn_id: str, change_id: bool = True
+) -> WorkGraph:
+    """Delete a task from a work graph.
+
+    Удалить задачу из графа работ.
+
+    If the task consists of inseparable nodes, all of them are removed.
+    Если задача содержит неразделимые узлы, удаляются все они.
+
+    Args:
+        original_wg: WorkGraph from which the task is removed.
+            WorkGraph, из которого удаляется задача.
+        remove_gn_id: Identifier of any node from the task to delete.
+            Идентификатор любого узла удаляемой задачи.
+        change_id: Whether to generate new identifiers in the copy.
+            Требуется ли генерировать новые идентификаторы в копии.
+
+    Returns:
+        Work graph without the specified task.
+        Граф работ без указанной задачи.
     """
     copied_nodes, old_to_new_ids = prepare_work_graph_copy(original_wg, change_id=change_id)
 

--- a/sampo/structurator/graph_insertion.py
+++ b/sampo/structurator/graph_insertion.py
@@ -1,19 +1,38 @@
+"""Utilities for inserting one work graph into another.
+
+Утилиты для вставки одного графа работ в другой.
+"""
+
 from sampo.schemas.graph import GraphNode, WorkGraph
 from sampo.structurator.prepare_wg_copy import prepare_work_graph_copy, new_start_finish
 
 
-def graph_in_graph_insertion(master_wg: WorkGraph, master_start: GraphNode, master_finish: GraphNode,
-                             slave_wg: WorkGraph, change_id: bool = True) -> WorkGraph:
-    """
-    Inserts the slave WorkGraph into the master WorkGraph,
-    while the starting vertex slave_wg becomes the specified master_start,
-    and the finishing vertex is correspondingly master_finish
-    :param master_wg: the WorkGraph into which the insertion is performed
-    :param master_start: GraphNode which will become the parent for the entire slave_wg
-    :param master_finish: GraphNode which will become a child for the whole slave_wg
-    :param slave_wg: WorkGraph to be inserted into master_wg
-    :param change_id: do ids in the new graph need to be changed
-    :return: new union WorkGraph
+def graph_in_graph_insertion(
+    master_wg: WorkGraph,
+    master_start: GraphNode,
+    master_finish: GraphNode,
+    slave_wg: WorkGraph,
+    change_id: bool = True,
+) -> WorkGraph:
+    """Insert a work graph into another between two nodes.
+
+    Вставить один граф работ в другой между двумя узлами.
+
+    Args:
+        master_wg: The graph into which insertion is performed.
+            Граф, в который выполняется вставка.
+        master_start: Node that becomes the parent for the inserted graph.
+            Узел, который становится родителем вставляемого графа.
+        master_finish: Node that becomes the child for the inserted graph.
+            Узел, который становится потомком вставляемого графа.
+        slave_wg: Graph to be inserted into the master graph.
+            Граф, который вставляется в основной граф.
+        change_id: Whether to generate new identifiers.
+            Нужно ли генерировать новые идентификаторы.
+
+    Returns:
+        Combined work graph.
+        Объединенный граф работ.
     """
     master_nodes, master_old_to_new_ids = prepare_work_graph_copy(master_wg, change_id=change_id)
     slave_nodes, slave_old_to_new = prepare_work_graph_copy(slave_wg, [slave_wg.start, slave_wg.finish], change_id)

--- a/sampo/structurator/insert_wu.py
+++ b/sampo/structurator/insert_wu.py
@@ -1,20 +1,39 @@
+"""Routines for inserting single work units into a graph.
+
+Процедуры вставки отдельных рабочих операций в граф.
+"""
+
 from sampo.schemas.graph import GraphNode, EdgeType, WorkGraph
 from sampo.schemas.works import WorkUnit
 from sampo.structurator.prepare_wg_copy import prepare_work_graph_copy, new_start_finish
 
 
-def insert_work_unit(original_wg: WorkGraph, inserted_wu: WorkUnit,
-                     parents_edges: list[GraphNode] or list[tuple[GraphNode, float, EdgeType]],
-                     children_edges: list[GraphNode] or list[tuple[GraphNode, float, EdgeType]],
-                     change_id: bool = True) -> WorkGraph:
-    """
-    Inserts new node in the WorkGraph, based on given WorkUnit
-    :param original_wg: WorkGraph into which we insert new node
-    :param inserted_wu: WorkUnit on the basis of which we create new GraphNode
-    :param parents_edges: nodes which are supposed to be the parents of new GraphNode
-    :param children_edges: nodes which are supposed to be the children of new GraphNode
-    :param change_id: do ids in the new graph need to be changed
-    :return: new WorkGraph with inserted new node
+def insert_work_unit(
+    original_wg: WorkGraph,
+    inserted_wu: WorkUnit,
+    parents_edges: list[GraphNode] | list[tuple[GraphNode, float, EdgeType]],
+    children_edges: list[GraphNode] | list[tuple[GraphNode, float, EdgeType]],
+    change_id: bool = True,
+) -> WorkGraph:
+    """Insert a new node into a work graph.
+
+    Вставить новый узел в граф работ.
+
+    Args:
+        original_wg: Graph where the node will be inserted.
+            Граф, в который вставляется новый узел.
+        inserted_wu: Work unit used to create the node.
+            Производственная операция, из которой создается узел.
+        parents_edges: Parents for the new node.
+            Родительские узлы для нового узла.
+        children_edges: Children for the new node.
+            Дочерние узлы для нового узла.
+        change_id: Whether to generate new identifiers.
+            Нужно ли генерировать новые идентификаторы.
+
+    Returns:
+        New work graph with the inserted node.
+        Новый граф работ с вставленным узлом.
     """
     reduced_parent_edges = _reduce_to_tuple_type(parents_edges)
     reduced_children_edges = _reduce_to_tuple_type(children_edges)

--- a/sampo/structurator/light_modifications.py
+++ b/sampo/structurator/light_modifications.py
@@ -1,15 +1,31 @@
+"""Lightweight transformations for work graphs.
+
+Легкие преобразования графов работ.
+"""
+
 from sampo.schemas.graph import WorkGraph
 from sampo.structurator.graph_insertion import prepare_work_graph_copy
 from sampo.structurator.prepare_wg_copy import new_start_finish
 
 
-def work_graph_ids_simplification(wg: WorkGraph, id_offset: int = 0, change_id: bool = True) -> WorkGraph:
-    """
-    Creates a new WorkGraph with simplified numeric ids (numeric ids are converted to a string)
-    :param wg: original WorkGraph
-    :param id_offset: start for numbering new ids
-    :param change_id: Do IDs in the new graph need to be changed
-    :return: new WorkGraph with numeric ids
+def work_graph_ids_simplification(
+    wg: WorkGraph, id_offset: int = 0, change_id: bool = True
+) -> WorkGraph:
+    """Create a copy of a graph with simplified numeric identifiers.
+
+    Создать копию графа с упрощенными числовыми идентификаторами.
+
+    Args:
+        wg: Original work graph.
+            Исходный граф работ.
+        id_offset: Starting number for new identifiers.
+            Начальное число для новых идентификаторов.
+        change_id: Whether to generate new identifiers.
+            Нужно ли генерировать новые идентификаторы.
+
+    Returns:
+        Work graph with numeric identifiers.
+        Граф работ с числовыми идентификаторами.
     """
     nodes, old_to_new_ids = prepare_work_graph_copy(wg, [], use_ids_simplification=True, id_offset=id_offset)
     start = nodes[old_to_new_ids[wg.start.id]]

--- a/sampo/structurator/prepare_wg_copy.py
+++ b/sampo/structurator/prepare_wg_copy.py
@@ -1,3 +1,8 @@
+"""Helpers for copying work graphs and restoring connections.
+
+Вспомогательные функции для копирования графов работ и восстановления связей.
+"""
+
 from copy import deepcopy
 
 from sampo.schemas.graph import GraphNode, WorkGraph
@@ -5,14 +10,24 @@ from sampo.schemas.utils import uuid_str
 from sampo.schemas.works import WorkUnit
 
 
-def copy_graph_node(node: GraphNode, new_id: int | str | None = None,
-                    change_id: bool = True) -> tuple[GraphNode, tuple[str, str]]:
-    """
-    Makes a deep copy of GraphNode without edges. It's id can be changed to a new randomly generated or specified one
-    :param node: original GraphNode
-    :param new_id: specified new id
-    :param change_id: do ids in the new graph need to be changed
-    :return: copy of GraphNode and pair(old node id, new node id)
+def copy_graph_node(
+    node: GraphNode, new_id: int | str | None = None, change_id: bool = True
+) -> tuple[GraphNode, tuple[str, str]]:
+    """Deep-copy a node optionally changing its identifier.
+
+    Создать глубокую копию узла с возможной сменой идентификатора.
+
+    Args:
+        node: Original graph node.
+            Исходный узел графа.
+        new_id: Desired identifier for the copy.
+            Желаемый идентификатор для копии.
+        change_id: Whether to generate a new identifier if none provided.
+            Нужно ли генерировать новый идентификатор, если он не задан.
+
+    Returns:
+        Tuple of the new node and pair of old and new identifiers.
+        Кортеж из нового узла и пары старого и нового идентификаторов.
     """
     if change_id:
         new_id = new_id or uuid_str()
@@ -31,15 +46,29 @@ def copy_graph_node(node: GraphNode, new_id: int | str | None = None,
     return GraphNode(new_wu, []), (wu.id, new_id)
 
 
-def restore_parents(new_nodes: dict[str, GraphNode], original_wg: WorkGraph, old_to_new_ids: dict[str, str],
-                    excluded_ids: set[str]) -> None:
-    """
-    Restores edges in GraphNode for copied WorkGraph with changed ids
-    :param new_nodes: needed copied nodes
-    :param original_wg: original WorkGraph for edge restoring for new nodes
-    :param excluded_ids: dictionary of relationships between old ids and new ids
-    :param old_to_new_ids: a dictionary linking the ids of GraphNodes of the original graph and the new GraphNode ids
-    :return:
+def restore_parents(
+    new_nodes: dict[str, GraphNode],
+    original_wg: WorkGraph,
+    old_to_new_ids: dict[str, str],
+    excluded_ids: set[str],
+) -> None:
+    """Restore parent edges for copied nodes.
+
+    Восстановить ребра к родителям для скопированных узлов.
+
+    Args:
+        new_nodes: Copied nodes.
+            Скопированные узлы.
+        original_wg: Original work graph used for reference.
+            Исходный граф работ, используемый для ссылки.
+        old_to_new_ids: Mapping from old identifiers to new ones.
+            Отображение от старых идентификаторов к новым.
+        excluded_ids: Set of node identifiers that should be ignored.
+            Множество идентификаторов узлов, которые следует игнорировать.
+
+    Returns:
+        None
+        None
     """
     for node in original_wg.nodes:
         if node.id in old_to_new_ids and node.id not in excluded_ids:
@@ -49,20 +78,34 @@ def restore_parents(new_nodes: dict[str, GraphNode], original_wg: WorkGraph, old
                                   if edge.start.id in old_to_new_ids and edge.start.id not in excluded_ids])
 
 
-def prepare_work_graph_copy(wg: WorkGraph, excluded_nodes: list[GraphNode] = [], use_ids_simplification: bool = False,
-                            id_offset: int = 0, change_id: bool = True) -> tuple[dict[str, GraphNode], dict[str, str]]:
+def prepare_work_graph_copy(
+    wg: WorkGraph,
+    excluded_nodes: list[GraphNode] | None = None,
+    use_ids_simplification: bool = False,
+    id_offset: int = 0,
+    change_id: bool = True,
+) -> tuple[dict[str, GraphNode], dict[str, str]]:
+    """Create a copy of a work graph with new identifiers.
+
+    Создать копию графа работ с новыми идентификаторами.
+
+    Args:
+        wg: Original work graph.
+            Исходный граф работ.
+        excluded_nodes: Nodes to exclude from the copy.
+            Узлы, исключаемые из копии.
+        use_ids_simplification: Whether to use short numeric identifiers.
+            Использовать ли короткие числовые идентификаторы.
+        id_offset: Offset for numeric identifiers.
+            Смещение для числовых идентификаторов.
+        change_id: Whether to generate new identifiers.
+            Нужно ли генерировать новые идентификаторы.
+
+    Returns:
+        Dictionary of new nodes and mapping from old to new identifiers.
+        Словарь новых узлов и отображение старых идентификаторов в новые.
     """
-    Makes a deep copy of the GraphNodes of the original graph with new ids and updated edges,
-    ignores all GraphNodes specified in the exception list and GraphEdges associated with them
-    :param wg: original WorkGraph for copy
-    :param excluded_nodes: GraphNodes to be excluded from the graph
-    :param use_ids_simplification: If true, creates short numeric ids converted to strings,
-    otherwise uses uuid to generate id
-    :param id_offset: Shift for numeric ids, used only if param use_ids_simplification is True
-    :param change_id: Do IDs in the new graph need to be changed
-    :return: A dictionary with GraphNodes by their id
-    and a dictionary linking the ids of GraphNodes of the original graph and the new GraphNode ids
-    """
+    excluded_nodes = excluded_nodes or []
     excluded_nodes = {node.id for node in excluded_nodes}
     node_list = [(id_offset + ind, node) for ind, node in enumerate(wg.nodes)] \
         if use_ids_simplification \
@@ -75,14 +118,26 @@ def prepare_work_graph_copy(wg: WorkGraph, excluded_nodes: list[GraphNode] = [],
     return nodes, id_old_to_new
 
 
-def new_start_finish(original_wg: WorkGraph, copied_nodes: dict[str, GraphNode],
-                     old_to_new_ids: dict[str, str]) -> tuple[GraphNode, GraphNode]:
-    """
-    Prepares new start and finish to create WorkGraph after copying it
-    :param original_wg: WorkGraph, on which base prepare_work_graph_copy was run
-    :param copied_nodes: New nodes, on which to create new WorkGraph
-    :param old_to_new_ids: Dictionary to translate old nodes to new, using their IDs
-    :return: new start and new finish nodes, on the base of which to create a WorkGraph
+def new_start_finish(
+    original_wg: WorkGraph,
+    copied_nodes: dict[str, GraphNode],
+    old_to_new_ids: dict[str, str],
+) -> tuple[GraphNode, GraphNode]:
+    """Return start and finish nodes for a copied graph.
+
+    Вернуть начальный и конечный узлы для скопированного графа.
+
+    Args:
+        original_wg: Work graph used for copying.
+            Граф работ, использованный для копирования.
+        copied_nodes: Nodes of the copied graph.
+            Узлы скопированного графа.
+        old_to_new_ids: Mapping from old identifiers to new ones.
+            Отображение от старых идентификаторов к новым.
+
+    Returns:
+        Pair of start and finish nodes for the new graph.
+        Пара начального и конечного узлов для нового графа.
     """
     new_start = copied_nodes[old_to_new_ids[original_wg.start.id]]
     new_finish = copied_nodes[old_to_new_ids[original_wg.finish.id]]


### PR DESCRIPTION
## Summary
- add bilingual module docstrings and Google-style API docstrings across structurator modules

## Testing
- `flake8 sampo/structurator || true`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e74ee23c832ea532b4ddc76c9a02