### PR TITLE
Add bilingual docstrings for user input parsers

### DIFF
--- a/sampo/userinput/__init__.py
+++ b/sampo/userinput/__init__.py
@@ -1,1 +1,10 @@
-from sampo.userinput.parser import ContractorType, CSVParser, InputDataException, WorkGraphBuildingException
+"""Utilities for parsing user input into SAMPO structures.
+
+Утилиты для преобразования пользовательского ввода в структуры SAMPO."""
+
+from sampo.userinput.parser import (
+    ContractorType,
+    CSVParser,
+    InputDataException,
+    WorkGraphBuildingException,
+)

--- a/sampo/userinput/parser/__init__.py
+++ b/sampo/userinput/parser/__init__.py
@@ -1,3 +1,10 @@
+"""Helpers for reading project data and constructing work graphs.
+
+Вспомогательные инструменты для чтения данных проекта и построения графов работ."""
+
 from sampo.userinput.parser.contractor_type import ContractorType
 from sampo.userinput.parser.csv_parser import CSVParser
-from sampo.userinput.parser.exception import InputDataException, WorkGraphBuildingException
+from sampo.userinput.parser.exception import (
+    InputDataException,
+    WorkGraphBuildingException,
+)

--- a/sampo/userinput/parser/contractor_type.py
+++ b/sampo/userinput/parser/contractor_type.py
@@ -1,10 +1,26 @@
+"""Definitions of contractor capability tiers.
+
+Определения уровней возможностей подрядчиков."""
+
 from enum import Enum
+
+# pylint: disable=invalid-name
 
 
 class ContractorType(Enum):
+    """Levels of contractor performance.
+
+    Уровни производительности подрядчика.
+    """
+
     Minimal = 50
     Average = 75
     Maximal = 200
 
     def command_capacity(self) -> int:
+        """Return command capacity in man-hours.
+
+        Возвращает командную мощность в человеко-часах.
+        """
+
         return self.value

--- a/sampo/userinput/parser/exception.py
+++ b/sampo/userinput/parser/exception.py
@@ -1,14 +1,33 @@
+"""Custom exceptions for user input processing.
+
+Пользовательские исключения для обработки пользовательского ввода."""
+
+
 class WorkGraphBuildingException(Exception):
+    """Raised when work graph can't be built.
+
+    Возникает, когда невозможно построить граф работ.
     """
-    Raised when work graph can't be built
-    """
+
     def __init__(self, message: str):
+        """Store error description.
+
+        Сохраняет описание ошибки.
+        """
+
         super().__init__(message)
 
 
 class InputDataException(Exception):
+    """Raised when information about task links is missing.
+
+    Возникает при отсутствии информации о связях задач.
     """
-    Raise when there isn't info about tasks' connection
-    """
+
     def __init__(self, reason: str):
+        """Store textual reason of the failure.
+
+        Сохраняет текстовую причину ошибки.
+        """
+
         super().__init__("The reason of Input Data exception is " + reason)


### PR DESCRIPTION
## Summary
- document user input facade
- clarify contractor type enum
- describe custom input exceptions

## Testing
- `pylint sampo/userinput/__init__.py sampo/userinput/parser/__init__.py sampo/userinput/parser/contractor_type.py sampo/userinput/parser/exception.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e750837c832eb11d9b2fa2343091