### PR TITLE
Add bilingual docstrings for sampler utilities

### DIFF
--- a/sampo/utilities/sampler/__init__.py
+++ b/sampo/utilities/sampler/__init__.py
@@ -1,3 +1,9 @@
+"""Sampling utilities for generating random scheduling entities.
+
+Sampling utilities for generating random scheduling entities.
+Утилиты выборки для генерации случайных сущностей расписания.
+"""
+
 import random
 from typing import Optional, List, Tuple, Hashable
 
@@ -10,55 +16,199 @@ from sampo.utilities.sampler.works import get_work_unit, get_similar_work_unit
 
 
 class Sampler:
-    def __init__(self,
-                 seed: Optional[Hashable] = None
-                 ):
+    """Generates random work units and graph nodes.
+
+    Generates random work units and graph nodes.
+    Генерирует случайные рабочие единицы и узлы графа.
+    """
+
+    def __init__(self, seed: Optional[Hashable] = None) -> None:
+        """Create sampler with optional random seed.
+
+        Create sampler with optional random seed.
+        Создает объект выборки с необязательным случайным зерном.
+
+        Args:
+            seed: Base for random generator. seed: Основа для генератора
+                случайных чисел.
+        """
+
         self.rand = random.Random(seed)
 
-    def worker_reqs(self,
-                    volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                    worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                    ) -> List[WorkerReq]:
+    def worker_reqs(
+        self,
+        volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+        worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+    ) -> List[WorkerReq]:
+        """Generate random worker requirements.
+
+        Generate random worker requirements.
+        Сгенерировать случайные требования к рабочим.
+
+        Args:
+            volume: Range of total work volume. volume: Диапазон общего
+                объема работ.
+            worker_count: Range of worker numbers. worker_count: Диапазон
+                количества рабочих.
+
+        Returns:
+            List[WorkerReq]: Worker requirements list. List[WorkerReq]:
+                Список требований к рабочим.
+        """
+
         return get_worker_reqs_list(self.rand, volume, worker_count)
 
-    def work_unit(self,
-                  name: str,
-                  work_id: Optional[str] = '',
-                  volume_type: Optional[str] = 'unit',
-                  group: Optional[str] = 'default',
-                  work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
-                  req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                  req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                  ) -> WorkUnit:
-        return get_work_unit(self.rand, name, work_id, volume_type, group, work_volume, req_volume, req_worker_count)
+    def work_unit(
+        self,
+        name: str,
+        work_id: Optional[str] = "",
+        volume_type: Optional[str] = "unit",
+        group: Optional[str] = "default",
+        work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
+        req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+        req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+    ) -> WorkUnit:
+        """Create a random work unit.
 
-    def similar_work_unit(self,
-                          exemplar: WorkUnit,
-                          scalar: Optional[float] = 1.0,
-                          name: Optional[str] = '',
-                          work_id: Optional[str] = ''
-                          ) -> WorkUnit:
+        Create a random work unit.
+        Создать случайную рабочую единицу.
+
+        Args:
+            name: Work unit name. name: Название рабочей единицы.
+            work_id: Identifier of work unit. work_id: Идентификатор
+                рабочей единицы.
+            volume_type: Unit of volume. volume_type: Единица измерения
+                объема.
+            group: Group for generated work. group: Группа для
+                сгенерированной работы.
+            work_volume: Range for work volume. work_volume: Диапазон
+                объема работ.
+            req_volume: Range for requirement volume. req_volume:
+                Диапазон объема требований.
+            req_worker_count: Range of workers per requirement.
+                req_worker_count: Диапазон числа рабочих на требование.
+
+        Returns:
+            WorkUnit: Generated work unit. WorkUnit: Сгенерированная
+                рабочая единица.
+        """
+
+        return get_work_unit(
+            self.rand,
+            name,
+            work_id,
+            volume_type,
+            group,
+            work_volume,
+            req_volume,
+            req_worker_count,
+        )
+
+    def similar_work_unit(
+        self,
+        exemplar: WorkUnit,
+        scalar: Optional[float] = 1.0,
+        name: Optional[str] = "",
+        work_id: Optional[str] = "",
+    ) -> WorkUnit:
+        """Create work unit similar to exemplar.
+
+        Create work unit similar to exemplar.
+        Создать рабочую единицу, похожую на образец.
+
+        Args:
+            exemplar: Source work unit. exemplar: Исходная рабочая
+                единица.
+            scalar: Scale factor for volume. scalar: Коэффициент масштабирования
+                объема.
+            name: New name if provided. name: Новое имя, если указано.
+            work_id: New identifier if provided. work_id: Новый
+                идентификатор, если указан.
+
+        Returns:
+            WorkUnit: Generated similar work unit. WorkUnit:
+                Сгенерированная похожая рабочая единица.
+        """
+
         return get_similar_work_unit(self.rand, exemplar, scalar, name, work_id)
 
-    def graph_node(self,
-                   name: str,
-                   edges: List[Tuple[GraphNode, float, EdgeType]],
-                   work_id: Optional[str] = '',
-                   volume_type: Optional[str] = 'unit',
-                   group: Optional[str] = 'default',
-                   work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
-                   req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                   req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                   ) -> GraphNode:
-        wu = get_work_unit(self.rand, name, work_id, volume_type, group, work_volume, req_volume, req_worker_count)
+    def graph_node(
+        self,
+        name: str,
+        edges: List[Tuple[GraphNode, float, EdgeType]],
+        work_id: Optional[str] = "",
+        volume_type: Optional[str] = "unit",
+        group: Optional[str] = "default",
+        work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
+        req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+        req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+    ) -> GraphNode:
+        """Create graph node with random work unit.
+
+        Create graph node with random work unit.
+        Создать узел графа со случайной рабочей единицей.
+
+        Args:
+            name: Node name. name: Название узла.
+            edges: Connections to other nodes. edges: Связи с другими
+                узлами.
+            work_id: Identifier of work unit. work_id: Идентификатор
+                рабочей единицы.
+            volume_type: Unit of volume. volume_type: Единица измерения
+                объема.
+            group: Group for generated work. group: Группа
+                сгенерированной работы.
+            work_volume: Range for work volume. work_volume: Диапазон
+                объема работ.
+            req_volume: Range for requirement volume. req_volume:
+                Диапазон объема требований.
+            req_worker_count: Range of workers per requirement.
+                req_worker_count: Диапазон числа рабочих на требование.
+
+        Returns:
+            GraphNode: Generated graph node. GraphNode: Сгенерированный
+                узел графа.
+        """
+
+        wu = get_work_unit(
+            self.rand,
+            name,
+            work_id,
+            volume_type,
+            group,
+            work_volume,
+            req_volume,
+            req_worker_count,
+        )
         return GraphNode(wu, edges)
 
-    def similar_graph_node(self,
-                           exemplar: GraphNode,
-                           edges: List[Tuple[GraphNode, float, EdgeType]],
-                           scalar: Optional[float] = 1.0,
-                           name: Optional[str] = '',
-                           work_id: Optional[str] = ''
-                           ) -> GraphNode:
+    def similar_graph_node(
+        self,
+        exemplar: GraphNode,
+        edges: List[Tuple[GraphNode, float, EdgeType]],
+        scalar: Optional[float] = 1.0,
+        name: Optional[str] = "",
+        work_id: Optional[str] = "",
+    ) -> GraphNode:
+        """Create node similar to exemplar.
+
+        Create node similar to exemplar.
+        Создать узел, похожий на образец.
+
+        Args:
+            exemplar: Source node. exemplar: Исходный узел.
+            edges: Connections to other nodes. edges: Связи с другими
+                узлами.
+            scalar: Scale factor for volume. scalar: Коэффициент
+                масштабирования объема.
+            name: New name if provided. name: Новое имя, если указано.
+            work_id: New identifier if provided. work_id: Новый
+                идентификатор, если указан.
+
+        Returns:
+            GraphNode: Generated similar node. GraphNode: Сгенерированный
+                похожий узел.
+        """
+
         wu = get_similar_work_unit(self.rand, exemplar.work_unit, scalar, name, work_id)
         return GraphNode(wu, edges)

--- a/sampo/utilities/sampler/requirements.py
+++ b/sampo/utilities/sampler/requirements.py
@@ -1,24 +1,69 @@
+"""Utilities for generating worker requirements.
+
+Utilities for generating worker requirements.
+Утилиты для генерации требований к рабочим.
+"""
+
 import random
 from typing import Optional
 
 from sampo.schemas.requirements import WorkerReq
-from sampo.utilities.sampler.resources import WORKER_TYPES, WorkerSpecialization
+from sampo.utilities.sampler.resources import (
+    WORKER_TYPES,
+    WorkerSpecialization,
+)
 from sampo.utilities.sampler.types import MinMax
 
 
-def get_worker_req(rand: random.Random,
-                   name: str,
-                   volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                   worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                   ) -> WorkerReq:
+def get_worker_req(
+    rand: random.Random,
+    name: str,
+    volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+    worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+) -> WorkerReq:
+    """Generate requirement for a single worker type.
+
+    Generate requirement for a single worker type.
+    Сгенерировать требование для одного типа рабочего.
+
+    Args:
+        rand: Random generator. rand: Генератор случайных чисел.
+        name: Worker specialization. name: Специализация рабочего.
+        volume: Range of required volume. volume: Диапазон требуемого объема.
+        worker_count: Range of workers per unit. worker_count: Диапазон
+            рабочих на единицу.
+
+    Returns:
+        WorkerReq: Requirement description. WorkerReq: Описание
+            требования.
+    """
+
     count = rand.randint(volume.min, volume.max)
     return WorkerReq(name, count, worker_count.min, worker_count.max)
 
 
-def get_worker_reqs_list(rand: random.Random,
-                         volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                         worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                         ) -> list[WorkerReq]:
+def get_worker_reqs_list(
+    rand: random.Random,
+    volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+    worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+) -> list[WorkerReq]:
+    """Generate list of random worker requirements.
+
+    Generate list of random worker requirements.
+    Сгенерировать список случайных требований к рабочим.
+
+    Args:
+        rand: Random generator. rand: Генератор случайных чисел.
+        volume: Range of required volume. volume: Диапазон требуемого
+            объема.
+        worker_count: Range of workers per unit. worker_count: Диапазон
+            рабочих на единицу.
+
+    Returns:
+        list[WorkerReq]: Worker requirements list. list[WorkerReq]: Список
+            требований к рабочим.
+    """
+
     names: list[WorkerSpecialization] = list(WORKER_TYPES)
     rand.shuffle(names)
     req_count = rand.randint(1, len(names))
@@ -26,9 +71,28 @@ def get_worker_reqs_list(rand: random.Random,
     return get_worker_specific_reqs_list(rand, names, volume, worker_count)
 
 
-def get_worker_specific_reqs_list(rand: random.Random,
-                                  worker_names: list[WorkerSpecialization],
-                                  volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                                  worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                                  ) -> list[WorkerReq]:
+def get_worker_specific_reqs_list(
+    rand: random.Random,
+    worker_names: list[WorkerSpecialization],
+    volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+    worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+) -> list[WorkerReq]:
+    """Generate requirements for specific worker types.
+
+    Generate requirements for specific worker types.
+    Сгенерировать требования для конкретных типов рабочих.
+
+    Args:
+        rand: Random generator. rand: Генератор случайных чисел.
+        worker_names: Specializations list. worker_names: Список специализаций.
+        volume: Range of required volume. volume: Диапазон требуемого
+            объема.
+        worker_count: Range of workers per unit. worker_count: Диапазон
+            рабочих на единицу.
+
+    Returns:
+        list[WorkerReq]: Worker requirements list. list[WorkerReq]: Список
+            требований к рабочим.
+    """
+
     return [get_worker_req(rand, name, volume, worker_count) for name in worker_names]

--- a/sampo/utilities/sampler/resources.py
+++ b/sampo/utilities/sampler/resources.py
@@ -1,12 +1,20 @@
+"""Predefined worker specializations for sampling.
+
+Predefined worker specializations for sampling.
+Предопределенные специализации рабочих для выборки.
+"""
+
 from typing import FrozenSet
 
 WorkerSpecialization = str
 
-DRIVER: WorkerSpecialization = 'driver'
-FITTER: WorkerSpecialization = 'fitter'
-HANDYMAN: WorkerSpecialization = 'handyman'
-ELECTRICIAN: WorkerSpecialization = 'electrician'
-MANAGER: WorkerSpecialization = 'manager'
-ENGINEER: WorkerSpecialization = 'engineer'
+DRIVER: WorkerSpecialization = "driver"
+FITTER: WorkerSpecialization = "fitter"
+HANDYMAN: WorkerSpecialization = "handyman"
+ELECTRICIAN: WorkerSpecialization = "electrician"
+MANAGER: WorkerSpecialization = "manager"
+ENGINEER: WorkerSpecialization = "engineer"
 
-WORKER_TYPES: FrozenSet[WorkerSpecialization] = frozenset({DRIVER, FITTER, HANDYMAN, ELECTRICIAN, MANAGER, ENGINEER})
+WORKER_TYPES: FrozenSet[WorkerSpecialization] = frozenset(
+    {DRIVER, FITTER, HANDYMAN, ELECTRICIAN, MANAGER, ENGINEER}
+)

--- a/sampo/utilities/sampler/types.py
+++ b/sampo/utilities/sampler/types.py
@@ -1,10 +1,26 @@
+"""Common type utilities for sampler.
+
+Common type utilities for sampler.
+Общие типовые утилиты для выборки.
+"""
+
 from dataclasses import dataclass
 from typing import TypeVar, Generic
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
 class MinMax(Generic[T]):
+    """Range with minimum and maximum values.
+
+    Range with minimum and maximum values.
+    Диапазон с минимальным и максимальным значениями.
+
+    Attributes:
+        min: Lower bound. min: Нижняя граница.
+        max: Upper bound. max: Верхняя граница.
+    """
+
     min: T
     max: T

--- a/sampo/utilities/sampler/works.py
+++ b/sampo/utilities/sampler/works.py
@@ -1,3 +1,9 @@
+"""Work unit sampling helpers.
+
+Work unit sampling helpers.
+Вспомогательные функции выборки рабочих единиц.
+"""
+
 import random
 from typing import Optional
 
@@ -7,28 +13,87 @@ from sampo.utilities.sampler.requirements import get_worker_reqs_list
 from sampo.utilities.sampler.types import MinMax
 
 
-def get_work_unit(rand: random.Random, name: str,
-                  work_id: Optional[str] = '',
-                  volume_type: Optional[str] = 'unit',
-                  group: Optional[str] = 'default',
-                  work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
-                  req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
-                  req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100)
-                  ) -> WorkUnit:
+def get_work_unit(
+    rand: random.Random,
+    name: str,
+    work_id: Optional[str] = "",
+    volume_type: Optional[str] = "unit",
+    group: Optional[str] = "default",
+    work_volume: Optional[MinMax[float]] = MinMax[float](0.1, 100.0),
+    req_volume: Optional[MinMax[int]] = MinMax[int](1, 50),
+    req_worker_count: Optional[MinMax[int]] = MinMax[int](1, 100),
+) -> WorkUnit:
+    """Generate a random work unit.
+
+    Generate a random work unit.
+    Сгенерировать случайную рабочую единицу.
+
+    Args:
+        rand: Random generator. rand: Генератор случайных чисел.
+        name: Name of work unit. name: Название рабочей единицы.
+        work_id: Identifier of work unit. work_id: Идентификатор
+            рабочей единицы.
+        volume_type: Unit of volume. volume_type: Единица измерения объема.
+        group: Group of work. group: Группа работы.
+        work_volume: Range of work volume. work_volume: Диапазон объема
+            работ.
+        req_volume: Range of requirement volume. req_volume: Диапазон
+            объема требований.
+        req_worker_count: Range of worker numbers per requirement.
+            req_worker_count: Диапазон чисел рабочих на требование.
+
+    Returns:
+        WorkUnit: Generated work unit. WorkUnit: Сгенерированная рабочая
+            единица.
+    """
+
     reqs = get_worker_reqs_list(rand, req_volume, req_worker_count)
     work_id = work_id or uuid_str(rand)
     volume = rand.random() * (work_volume.max - work_volume.min) + work_volume.min
-    return WorkUnit(work_id, name, worker_reqs=reqs, volume=volume, volume_type=volume_type, group=group)
+    return WorkUnit(
+        work_id,
+        name,
+        worker_reqs=reqs,
+        volume=volume,
+        volume_type=volume_type,
+        group=group,
+    )
 
 
-def get_similar_work_unit(rand: random.Random,
-                          exemplar: WorkUnit,
-                          scalar: Optional[float] = 1.0,
-                          name: Optional[str] = '',
-                          work_id: Optional[str] = ''
-                          ) -> WorkUnit:
+def get_similar_work_unit(
+    rand: random.Random,
+    exemplar: WorkUnit,
+    scalar: Optional[float] = 1.0,
+    name: Optional[str] = "",
+    work_id: Optional[str] = "",
+) -> WorkUnit:
+    """Generate work unit similar to exemplar.
+
+    Generate work unit similar to exemplar.
+    Сгенерировать рабочую единицу, подобную образцу.
+
+    Args:
+        rand: Random generator. rand: Генератор случайных чисел.
+        exemplar: Base work unit. exemplar: Базовая рабочая единица.
+        scalar: Scale factor for volume. scalar: Коэффициент масштабирования
+            объема.
+        name: New name if provided. name: Новое имя, если указано.
+        work_id: New identifier if provided. work_id: Новый идентификатор,
+            если указан.
+
+    Returns:
+        WorkUnit: Generated work unit. WorkUnit: Сгенерированная рабочая
+            единица.
+    """
+
     reqs = [req.scale_all(scalar) for req in exemplar.worker_reqs]
     work_id = work_id or uuid_str(rand)
     name = name or exemplar.name
-    return WorkUnit(work_id, name, worker_reqs=reqs, group=exemplar.group,
-                    volume=exemplar.volume * scalar, volume_type=exemplar.volume_type)
+    return WorkUnit(
+        work_id,
+        name,
+        worker_reqs=reqs,
+        group=exemplar.group,
+        volume=exemplar.volume * scalar,
+        volume_type=exemplar.volume_type,
+    )


### PR DESCRIPTION
## Summary
- add bilingual module and function docstrings to sampler utilities
- document MinMax type and worker resources

## Testing
- `pylint sampo/utilities/sampler`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7529034832e837c975bc964bc88