### PR TITLE
Add bilingual docstrings to schedulers

### DIFF
--- a/sampo/scheduler/base.py
+++ b/sampo/scheduler/base.py
@@ -1,3 +1,7 @@
+"""Base scheduling types and abstract scheduler implementation.
+Базовые типы планировщиков и абстрактная реализация планировщика.
+"""
+
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Callable
@@ -5,7 +9,9 @@ from typing import Callable
 import numpy as np
 
 from sampo.scheduler.resource.base import ResourceOptimizer
-from sampo.scheduler.resource.coordinate_descent import CoordinateDescentResourceOptimizer
+from sampo.scheduler.resource.coordinate_descent import (
+    CoordinateDescentResourceOptimizer,
+)
 from sampo.scheduler.timeline.base import Timeline
 from sampo.schemas.contractor import Contractor
 from sampo.schemas.graph import WorkGraph, GraphNode
@@ -20,87 +26,158 @@ from sampo.utilities.base_opt import dichotomy_int
 
 
 class SchedulerType(Enum):
-    Genetic = 'genetic'
-    Topological = 'topological'
-    HEFTAddEnd = 'heft_add_end'
-    HEFTAddBetween = 'heft_add_between'
-    LFT = 'LFT'
+    """Enumeration of available scheduler implementations.
+    Перечисление доступных реализаций планировщика.
+    """
+
+    Genetic = "genetic"
+    Topological = "topological"
+    HEFTAddEnd = "heft_add_end"
+    HEFTAddBetween = "heft_add_between"
+    LFT = "LFT"
 
 
 class Scheduler(ABC):
+    """Base class that implements scheduling logic.
+    Базовый класс, реализующий логику планирования.
     """
-    Base class that implements the logic of the planning process.
-    """
+
     scheduler_type: SchedulerType
     resource_optimizer: ResourceOptimizer
 
-    def __init__(self,
-                 scheduler_type: SchedulerType,
-                 resource_optimizer: ResourceOptimizer = CoordinateDescentResourceOptimizer(dichotomy_int),
-                 work_estimator: WorkTimeEstimator = DefaultWorkEstimator()):
+    def __init__(
+        self,
+        scheduler_type: SchedulerType,
+        resource_optimizer: ResourceOptimizer = CoordinateDescentResourceOptimizer(
+            dichotomy_int
+        ),
+        work_estimator: WorkTimeEstimator = DefaultWorkEstimator(),
+    ):
+        """Initialize the scheduler.
+        Инициализирует планировщик.
+
+        Args:
+            scheduler_type: Type of scheduler implementation.
+                Тип реализации планировщика.
+            resource_optimizer: Optimizer for resource allocation.
+                Оптимизатор распределения ресурсов.
+            work_estimator: Work time estimator.
+                Оценщик времени выполнения работ.
+        """
         self.scheduler_type = scheduler_type
         self.resource_optimizer = resource_optimizer
         self.work_estimator = work_estimator
 
     def __str__(self) -> str:
+        """Return scheduler type name.
+        Возвращает имя типа планировщика.
+        """
         return str(self.scheduler_type.name)
 
-    def schedule(self,
-                 wg: WorkGraph,
-                 contractors: list[Contractor],
-                 spec: ScheduleSpec = ScheduleSpec(),
-                 validate: bool = False,
-                 start_time: Time = Time(0),
-                 timeline: Timeline | None = None,
-                 landscape: LandscapeConfiguration = LandscapeConfiguration()) \
-            -> list[Schedule]:
-        """
-        Implementation of a scheduling process. 'schedule' version returns only Schedule.
+    def schedule(
+        self,
+        wg: WorkGraph,
+        contractors: list[Contractor],
+        spec: ScheduleSpec = ScheduleSpec(),
+        validate: bool = False,
+        start_time: Time = Time(0),
+        timeline: Timeline | None = None,
+        landscape: LandscapeConfiguration = LandscapeConfiguration(),
+    ) -> list[Schedule]:
+        """Run the scheduling process and return schedules.
+        Запускает процесс планирования и возвращает расписания.
 
-        :return: Schedule
+        Args:
+            wg: Work graph to schedule.
+                Граф работ для планирования.
+            contractors: Available contractors.
+                Доступные подрядчики.
+            spec: Scheduling specification.
+                Спецификация планирования.
+            validate: Whether to validate the resulting schedule.
+                Нужно ли проверять полученное расписание.
+            start_time: Schedule start time.
+                Время начала расписания.
+            timeline: Optional timeline instance.
+                Необязательный экземпляр временной шкалы.
+            landscape: Landscape configuration.
+                Конфигурация ландшафта.
+
+        Returns:
+            list[Schedule]: Generated schedules.
+                Сформированные расписания.
+
+        Raises:
+            ValueError: If work graph or contractors are missing.
+                ValueError: Если граф работ или подрядчики отсутствуют.
         """
         if wg is None or len(wg.nodes) == 0:
-            raise ValueError('None or empty WorkGraph')
+            raise ValueError("None or empty WorkGraph")
         if contractors is None or len(contractors) == 0:
-            raise ValueError('None or empty contractor list')
-        schedules = self.schedule_with_cache(wg, contractors, spec, validate, start_time, timeline, landscape)
+            raise ValueError("None or empty contractor list")
+        schedules = self.schedule_with_cache(
+            wg, contractors, spec, validate, start_time, timeline, landscape
+        )
         schedules = [schedule[0] for schedule in schedules]
         # print(f'Schedule exec time: {schedule.execution_time} days')
         return schedules
 
     @abstractmethod
-    def schedule_with_cache(self,
-                            wg: WorkGraph,
-                            contractors: list[Contractor],
-                            spec: ScheduleSpec = ScheduleSpec(),
-                            validate: bool = False,
-                            assigned_parent_time: Time = Time(0),
-                            timeline: Timeline | None = None,
-                            landscape: LandscapeConfiguration = LandscapeConfiguration()) \
-            -> list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
-        """
-        Extended version of 'schedule' method. Returns much inner info
-        about a scheduling process, not only Schedule.
+    def schedule_with_cache(
+        self,
+        wg: WorkGraph,
+        contractors: list[Contractor],
+        spec: ScheduleSpec = ScheduleSpec(),
+        validate: bool = False,
+        assigned_parent_time: Time = Time(0),
+        timeline: Timeline | None = None,
+        landscape: LandscapeConfiguration = LandscapeConfiguration(),
+    ) -> list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
+        """Extended scheduling returning inner information.
+        Расширенное планирование, возвращающее внутреннюю информацию.
 
-        :return: resulting schedule, finish time,
-                 resulting timeline used for scheduling
-                 and node_order used for scheduling
+        Args:
+            wg: Work graph to schedule.
+                Граф работ для планирования.
+            contractors: Available contractors.
+                Доступные подрядчики.
+            spec: Scheduling specification.
+                Спецификация планирования.
+            validate: Whether to validate the resulting schedule.
+                Нужно ли проверять полученное расписание.
+            assigned_parent_time: Start time of the parent schedule.
+                Время начала родительского расписания.
+            timeline: Optional timeline instance.
+                Необязательный экземпляр временной шкалы.
+            landscape: Landscape configuration.
+                Конфигурация ландшафта.
+
+        Returns:
+            list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
+                Schedules with metadata.
+                Расписания с дополнительными данными.
         """
         ...
 
     @staticmethod
-    def optimize_resources_using_spec(work_unit: WorkUnit, worker_team: list[Worker], work_spec: WorkSpec,
-                                      optimize_lambda: Callable[[np.ndarray], None] = lambda _: None):
-        """
-        Applies worker team spec to an optimization process.
-        Can use arbitrary heuristics to increase spec handling efficiency.
+    def optimize_resources_using_spec(
+        work_unit: WorkUnit,
+        worker_team: list[Worker],
+        work_spec: WorkSpec,
+        optimize_lambda: Callable[[np.ndarray], None] = lambda _: None,
+    ):
+        """Apply a worker specification during optimization.
+        Применяет спецификацию работников в процессе оптимизации.
 
-        :param work_unit: current work unit
-        :param worker_team: current worker team from chosen contractor
-        :param work_spec: spec for given work unit
-        :param optimize_lambda: optimization func that should hold optimization
-            data in its closure and run optimization process when receives `optimize_array`.
-            Passing None or default value means this function should only apply spec.
+        Args:
+            work_unit: Current work unit.
+                Текущая работа.
+            worker_team: Worker team from the chosen contractor.
+                Команда работников выбранного подрядчика.
+            work_spec: Specification for the work unit.
+                Спецификация для данной работы.
+            optimize_lambda: Optimization callback using `optimize_array`.
+                Callback оптимизации, использующий `optimize_array`.
         """
         worker_reqs = set(wr.kind for wr in work_unit.worker_reqs)
         worker_team = [worker for worker in worker_team if worker.name in worker_reqs]
@@ -111,7 +188,7 @@ class Scheduler(ABC):
                 worker.count = work_spec.assigned_workers[worker.name]
         else:
             # create optimize array to save optimizing time
-            # this array should contain True if position should be optimized or False if shouldn't
+            # this array contains True for positions to optimize and False otherwise
             optimize_array = None
             if work_spec.assigned_workers:
                 optimize_array = []

--- a/sampo/scheduler/generic.py
+++ b/sampo/scheduler/generic.py
@@ -1,86 +1,192 @@
-from typing import Type, Callable, Iterable
+"""Generic scheduler implementation with pluggable strategies.
+Реализация универсального планировщика с подключаемыми стратегиями.
+"""
+
+from typing import Callable, Iterable, Type
 
 from sampo.scheduler.base import Scheduler, SchedulerType
-from sampo.scheduler.utils import (WorkerContractorPool, get_worker_contractor_pool,
-                                   get_head_nodes_with_connections_mappings)
-from sampo.scheduler.utils.time_computaion import calculate_working_time_cascade
 from sampo.scheduler.resource.base import ResourceOptimizer
 from sampo.scheduler.timeline.base import Timeline
-from sampo.scheduler.utils.multi_contractor import run_contractor_search, get_worker_borders
+from sampo.scheduler.utils import (
+    WorkerContractorPool,
+    get_head_nodes_with_connections_mappings,
+    get_worker_contractor_pool,
+)
+from sampo.scheduler.utils.multi_contractor import (
+    get_worker_borders,
+    run_contractor_search,
+)
+from sampo.scheduler.utils.time_computaion import calculate_working_time_cascade
 from sampo.schemas.contractor import Contractor
-from sampo.schemas.graph import WorkGraph, GraphNode
+from sampo.schemas.graph import GraphNode, WorkGraph
 from sampo.schemas.landscape import LandscapeConfiguration
 from sampo.schemas.resources import Worker
 from sampo.schemas.schedule import Schedule
 from sampo.schemas.schedule_spec import ScheduleSpec, WorkSpec
 from sampo.schemas.scheduled_work import ScheduledWork
 from sampo.schemas.time import Time
-from sampo.schemas.time_estimator import WorkTimeEstimator, DefaultWorkEstimator
+from sampo.schemas.time_estimator import DefaultWorkEstimator, WorkTimeEstimator
 from sampo.utilities.validation import validate_schedule
 
 
 # TODO Кажется, это не работает - лаги не учитываются
-def get_finish_time_default(node, worker_team, node2swork, spec, assigned_parent_time, timeline,
-                            work_estimator) -> Time:
-    return timeline.find_min_start_time(node, worker_team, node2swork, spec,
-                                        assigned_parent_time, work_estimator) \
-        + calculate_working_time_cascade(node, worker_team,
-                                         work_estimator)  # TODO Кажется, это не работает - лаги не учитываются
+def get_finish_time_default(
+    node,
+    worker_team,
+    node2swork,
+    spec,
+    assigned_parent_time,
+    timeline,
+    work_estimator,
+) -> Time:
+    """Estimate finish time using default method.
+    Оценивает время завершения стандартным методом.
+
+    Args:
+        node: Current graph node.
+            Текущая вершина графа.
+        worker_team: Worker team assigned to the node.
+            Команда работников, назначенная на вершину.
+        node2swork: Mapping of nodes to scheduled works.
+            Отображение вершин в запланированные работы.
+        spec: Work specification.
+            Спецификация работы.
+        assigned_parent_time: Parent start time.
+            Время начала родителя.
+        timeline: Timeline instance.
+            Экземпляр временной шкалы.
+        work_estimator: Work time estimator.
+            Оценщик времени выполнения работ.
+
+    Returns:
+        Time: Estimated finish time.
+            Оценка времени завершения.
+    """
+    return timeline.find_min_start_time(
+        node,
+        worker_team,
+        node2swork,
+        spec,
+        assigned_parent_time,
+        work_estimator,
+    ) + calculate_working_time_cascade(
+        node,
+        worker_team,
+        work_estimator,
+    )  # TODO Кажется, это не работает - лаги не учитываются
 
 
 PRIORITIZATION_F = Callable[
-    [list[GraphNode], dict[str, set[str]], dict[str, set[str]], WorkTimeEstimator], list[GraphNode]
+    [list[GraphNode], dict[str, set[str]], dict[str, set[str]], WorkTimeEstimator],
+    list[GraphNode],
 ]
-RESOURCE_OPTIMIZE_F = Callable[[GraphNode, list[Contractor], WorkSpec, WorkerContractorPool,
-                                dict[GraphNode, ScheduledWork], Time, Timeline, WorkTimeEstimator],
-                               tuple[Time, Time, Contractor, list[Worker]]]
+RESOURCE_OPTIMIZE_F = Callable[
+    [
+        GraphNode,
+        list[Contractor],
+        WorkSpec,
+        WorkerContractorPool,
+        dict[GraphNode, ScheduledWork],
+        Time,
+        Timeline,
+        WorkTimeEstimator,
+    ],
+    tuple[Time, Time, Contractor, list[Worker]],
+]
 
 
 class GenericScheduler(Scheduler):
-    """
-    Implementation of a universal scheme of scheduler.
-    It's parametrized by prioritization function and optimization resource function.
-    It constructs the end schedulers.
+    """Universal scheduler with customizable strategies.
+    Универсальный планировщик с настраиваемыми стратегиями.
     """
 
-    def __init__(self,
-                 scheduler_type: SchedulerType,
-                 resource_optimizer: ResourceOptimizer,
-                 timeline_type: Type,
-                 prioritization_f: PRIORITIZATION_F,
-                 optimize_resources_f: RESOURCE_OPTIMIZE_F,
-                 work_estimator: WorkTimeEstimator = DefaultWorkEstimator()):
+    def __init__(
+        self,
+        scheduler_type: SchedulerType,
+        resource_optimizer: ResourceOptimizer,
+        timeline_type: Type,
+        prioritization_f: PRIORITIZATION_F,
+        optimize_resources_f: RESOURCE_OPTIMIZE_F,
+        work_estimator: WorkTimeEstimator = DefaultWorkEstimator(),
+    ):
+        """Create a generic scheduler instance.
+        Создает экземпляр универсального планировщика.
+
+        Args:
+            scheduler_type: Type of scheduler implementation.
+                Тип реализации планировщика.
+            resource_optimizer: Resource optimization strategy.
+                Стратегия оптимизации ресурсов.
+            timeline_type: Timeline class to use.
+                Используемый класс временной шкалы.
+            prioritization_f: Node prioritization function.
+                Функция приоритизации узлов.
+            optimize_resources_f: Resource optimization function.
+                Функция оптимизации ресурсов.
+            work_estimator: Work time estimator.
+                Оценщик времени выполнения работ.
+        """
         super().__init__(scheduler_type, resource_optimizer, work_estimator)
         self._timeline_type = timeline_type
         self.prioritization = prioritization_f
         self.optimize_resources = optimize_resources_f
 
-    def get_default_res_opt_function(self, get_finish_time=get_finish_time_default) \
-            -> Callable[
-                [GraphNode, list[Contractor], WorkSpec, WorkerContractorPool,
-                 dict[GraphNode, ScheduledWork], Time, Timeline, WorkTimeEstimator],
-                tuple[Time, Time, Contractor, list[Worker]]
-            ]:
+    def get_default_res_opt_function(
+        self, get_finish_time=get_finish_time_default
+    ) -> Callable[
+        [
+            GraphNode,
+            list[Contractor],
+            WorkSpec,
+            WorkerContractorPool,
+            dict[GraphNode, ScheduledWork],
+            Time,
+            Timeline,
+            WorkTimeEstimator,
+        ],
+        tuple[Time, Time, Contractor, list[Worker]],
+    ]:
+        """Return default resource optimization function.
+        Возвращает функцию оптимизации ресурсов по умолчанию.
+
+        Args:
+            get_finish_time: Function estimating finish time.
+                Функция, оценивающая время завершения.
+
+        Returns:
+            Callable: Resource optimization function for scheduler construction.
+                Callable: Функция оптимизации ресурсов для создания планировщика.
         """
-        Here is default resource optimization getter function.
 
-        Constructs function that receives node with necessary scheduling inner info and
-        returns start time, finish time and assigned workers for that node.
-
-        :param get_finish_time: function that
-        :return: resource optimization function that can be passed as argument when constructing `GenericScheduler`.
-        """
-
-        def optimize_resources_def(node: GraphNode, contractors: list[Contractor], spec: WorkSpec,
-                                   worker_pool: WorkerContractorPool, node2swork: dict[GraphNode, ScheduledWork],
-                                   assigned_parent_time: Time, timeline: Timeline, work_estimator: WorkTimeEstimator):
+        def optimize_resources_def(
+            node: GraphNode,
+            contractors: list[Contractor],
+            spec: WorkSpec,
+            worker_pool: WorkerContractorPool,
+            node2swork: dict[GraphNode, ScheduledWork],
+            assigned_parent_time: Time,
+            timeline: Timeline,
+            work_estimator: WorkTimeEstimator,
+        ):
             def ft_getter(worker_team) -> Time:
-                return get_finish_time(node, worker_team, node2swork, spec,
-                                       assigned_parent_time, timeline, work_estimator)
+                return get_finish_time(
+                    node,
+                    worker_team,
+                    node2swork,
+                    spec,
+                    assigned_parent_time,
+                    timeline,
+                    work_estimator,
+                )
 
-            def run_with_contractor(contractor: Contractor) -> tuple[Time, Time, list[Worker]]:
-                min_count_worker_team, max_count_worker_team, workers \
-                    = get_worker_borders(worker_pool, contractor, node.work_unit.worker_reqs)
+            def run_with_contractor(
+                contractor: Contractor,
+            ) -> tuple[Time, Time, list[Worker]]:
+                min_count_worker_team, max_count_worker_team, workers = (
+                    get_worker_borders(
+                        worker_pool, contractor, node.work_unit.worker_reqs
+                    )
+                )
 
                 if len(workers) != len(node.work_unit.worker_reqs):
                     return assigned_parent_time, Time.inf(), []
@@ -88,41 +194,90 @@ class GenericScheduler(Scheduler):
                 workers = [worker.copy() for worker in workers]
 
                 # apply worker team spec
-                self.optimize_resources_using_spec(node.work_unit, workers, spec,
-                                                   lambda optimize_array: self.resource_optimizer.optimize_resources(
-                                                       worker_pool, workers,
-                                                       optimize_array,
-                                                       min_count_worker_team, max_count_worker_team,
-                                                       ft_getter))
+                self.optimize_resources_using_spec(
+                    node.work_unit,
+                    workers,
+                    spec,
+                    lambda optimize_array: self.resource_optimizer.optimize_resources(
+                        worker_pool,
+                        workers,
+                        optimize_array,
+                        min_count_worker_team,
+                        max_count_worker_team,
+                        ft_getter,
+                    ),
+                )
 
-                c_st, c_ft, _ = timeline.find_min_start_time_with_additional(node, workers, node2swork, spec, None,
-                                                                             assigned_parent_time, work_estimator)
+                c_st, c_ft, _ = timeline.find_min_start_time_with_additional(
+                    node,
+                    workers,
+                    node2swork,
+                    spec,
+                    None,
+                    assigned_parent_time,
+                    work_estimator,
+                )
                 return c_st, c_ft, workers
 
             return run_contractor_search(contractors, run_with_contractor)
 
         return optimize_resources_def
 
-    def schedule_with_cache(self,
-                            wg: WorkGraph,
-                            contractors: list[Contractor],
-                            spec: ScheduleSpec = ScheduleSpec(),
-                            validate: bool = False,
-                            assigned_parent_time: Time = Time(0),
-                            timeline: Timeline | None = None,
-                            landscape: LandscapeConfiguration() = LandscapeConfiguration()) \
-            -> list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
+    def schedule_with_cache(
+        self,
+        wg: WorkGraph,
+        contractors: list[Contractor],
+        spec: ScheduleSpec = ScheduleSpec(),
+        validate: bool = False,
+        assigned_parent_time: Time = Time(0),
+        timeline: Timeline | None = None,
+        landscape: LandscapeConfiguration() = LandscapeConfiguration(),
+    ) -> list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
+        """Schedule graph and return additional info.
+        Планирует граф и возвращает дополнительную информацию.
+
+        Args:
+            wg: Work graph to schedule.
+                Граф работ для планирования.
+            contractors: Available contractors.
+                Доступные подрядчики.
+            spec: Scheduling specification.
+                Спецификация планирования.
+            validate: Whether to validate the resulting schedule.
+                Нужно ли проверять полученное расписание.
+            assigned_parent_time: Start time of the parent schedule.
+                Время начала родительского расписания.
+            timeline: Optional timeline instance.
+                Необязательный экземпляр временной шкалы.
+            landscape: Landscape configuration.
+                Конфигурация ландшафта.
+
+        Returns:
+            list[tuple[Schedule, Time, Timeline, list[GraphNode]]]:
+                Schedules with execution context.
+                Расписания с контекстом выполнения.
+        """
         # get head nodes with mappings
-        head_nodes, node_id2parent_ids, node_id2child_ids = get_head_nodes_with_connections_mappings(wg)
+        head_nodes, node_id2parent_ids, node_id2child_ids = (
+            get_head_nodes_with_connections_mappings(wg)
+        )
 
-        ordered_nodes = self.prioritization(head_nodes, node_id2parent_ids, node_id2child_ids, self.work_estimator)
+        ordered_nodes = self.prioritization(
+            head_nodes, node_id2parent_ids, node_id2child_ids, self.work_estimator
+        )
 
-        schedule, schedule_start_time, timeline = \
-            self.build_scheduler(ordered_nodes, contractors, landscape, spec, self.work_estimator,
-                                 assigned_parent_time, timeline)
+        schedule, schedule_start_time, timeline = self.build_scheduler(
+            ordered_nodes,
+            contractors,
+            landscape,
+            spec,
+            self.work_estimator,
+            assigned_parent_time,
+            timeline,
+        )
         schedule = Schedule.from_scheduled_works(
             schedule,
-            wg
+            wg,
         )
 
         if validate:
@@ -130,28 +285,39 @@ class GenericScheduler(Scheduler):
 
         return [(schedule, schedule_start_time, timeline, ordered_nodes)]
 
-    def build_scheduler(self,
-                        ordered_nodes: list[GraphNode],
-                        contractors: list[Contractor],
-                        landscape: LandscapeConfiguration = LandscapeConfiguration(),
-                        spec: ScheduleSpec = ScheduleSpec(),
-                        work_estimator: WorkTimeEstimator = DefaultWorkEstimator(),
-                        assigned_parent_time: Time = Time(0),
-                        timeline: Timeline | None = None) \
-            -> tuple[Iterable[ScheduledWork], Time, Timeline]:
-        """
-        Find optimal number of workers who ensure the nearest finish time.
-        Finish time is combination of two dependencies: max finish time, max time of waiting of needed workers
-        This is selected by iteration from minimum possible numbers of workers until then the finish time is decreasing
+    def build_scheduler(
+        self,
+        ordered_nodes: list[GraphNode],
+        contractors: list[Contractor],
+        landscape: LandscapeConfiguration = LandscapeConfiguration(),
+        spec: ScheduleSpec = ScheduleSpec(),
+        work_estimator: WorkTimeEstimator = DefaultWorkEstimator(),
+        assigned_parent_time: Time = Time(0),
+        timeline: Timeline | None = None,
+    ) -> tuple[Iterable[ScheduledWork], Time, Timeline]:
+        """Construct schedule from ordered nodes.
+        Формирует расписание из упорядоченных узлов.
 
-        :param landscape:
-        :param contractors:
-        :param spec: spec for current scheduling
-        :param ordered_nodes:
-        :param timeline: the previous used timeline can be specified to handle previously scheduled works
-        :param assigned_parent_time: start time of the whole schedule(time shift)
-        :param work_estimator:
-        :return:
+        Args:
+            ordered_nodes: Nodes ordered for scheduling.
+                Узлы, упорядоченные для планирования.
+            contractors: Available contractors.
+                Доступные подрядчики.
+            landscape: Landscape configuration.
+                Конфигурация ландшафта.
+            spec: Specification for scheduling.
+                Спецификация для планирования.
+            work_estimator: Work time estimator.
+                Оценщик времени выполнения работ.
+            assigned_parent_time: Start time of the whole schedule.
+                Время начала всего расписания.
+            timeline: Optional timeline instance.
+                Необязательный экземпляр временной шкалы.
+
+        Returns:
+            tuple[Iterable[ScheduledWork], Time, Timeline]:
+                Scheduled works, start time, and timeline.
+                Запланированные работы, время начала и временная шкала.
         """
         worker_pool = get_worker_contractor_pool(contractors)
         # dict for writing parameters of completed_jobs
@@ -164,11 +330,18 @@ class GenericScheduler(Scheduler):
             work_unit = node.work_unit
             work_spec = spec.get_work_spec(work_unit.id)
 
-            start_time, finish_time, contractor, best_worker_team = self.optimize_resources(node, contractors,
-                                                                                            work_spec, worker_pool,
-                                                                                            node2swork,
-                                                                                            assigned_parent_time,
-                                                                                            timeline, work_estimator)
+            start_time, finish_time, contractor, best_worker_team = (
+                self.optimize_resources(
+                    node,
+                    contractors,
+                    work_spec,
+                    worker_pool,
+                    node2swork,
+                    assigned_parent_time,
+                    timeline,
+                    work_estimator,
+                )
+            )
 
             # we are scheduling the work `start of the project`
             if index == 0:
@@ -176,15 +349,28 @@ class GenericScheduler(Scheduler):
                 start_time = assigned_parent_time
                 finish_time += start_time
 
-            if index == len(ordered_nodes) - 1:  # we are scheduling the work `end of the project`
+            if (
+                index == len(ordered_nodes) - 1
+            ):  # we are scheduling the work `end of the project`
                 finish_time, finalizing_zones = timeline.zone_timeline.finish_statuses()
                 start_time = max(start_time, finish_time)
 
             # apply work to scheduling
-            timeline.schedule(node, node2swork, best_worker_team, contractor, work_spec,
-                              start_time, work_spec.assigned_time, assigned_parent_time, work_estimator)
+            timeline.schedule(
+                node,
+                node2swork,
+                best_worker_team,
+                contractor,
+                work_spec,
+                start_time,
+                work_spec.assigned_time,
+                assigned_parent_time,
+                work_estimator,
+            )
 
-            if index == len(ordered_nodes) - 1:  # we are scheduling the work `end of the project`
+            if (
+                index == len(ordered_nodes) - 1
+            ):  # we are scheduling the work `end of the project`
                 node2swork[node].zones_pre = finalizing_zones
 
         return node2swork.values(), assigned_parent_time, timeline


### PR DESCRIPTION
## Summary
- add English/Russian module docstrings to scheduler modules
- document public scheduler APIs with bilingual Google-style docstrings

## Testing
- `flake8 --max-line-length=88 --extend-ignore=E731,E402,F841 sampo/scheduler/base.py sampo/scheduler/generic.py sampo/scheduler/native_wrapper.py sampo/scheduler/topological/base.py`
- `pytest` *(interrupted: 59 passed, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ef25d5c0832e84ccad4936021bb6