### PR TITLE
Add bilingual docstrings for schema modules

### DIFF
--- a/sampo/schemas/interval.py
+++ b/sampo/schemas/interval.py
@@ -1,5 +1,10 @@
+"""Interval distributions for random number generation.
+
+Интервальные распределения для генерации случайных чисел.
+"""
+
 import random
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from random import Random
 from typing import Optional
@@ -17,60 +22,88 @@ MINUS_INF = float('-inf')
 
 
 class Interval(AutoJSONSerializable['BaseReq'], ABC):
-    """
-    A class for generating random numbers from a given boundary and distribution.
+    """Base interval with a probability distribution.
+
+    Базовый интервал с заданным распределением вероятностей.
     """
 
     @abstractmethod
     def rand_float(self, rand: Optional[random.Random] = None) -> float:
-        """
-        Returns a random float in the interval boundary according to the distribution of the class
+        """Return a random float within the interval.
 
-        :param rand: object for generating random numbers
-        :return kind: the random float
+        Возвращает случайное число с плавающей точкой в пределах интервала.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` for the
+                default. / Экземпляр генератора или ``None`` по умолчанию.
+
+        Returns:
+            float: Random value. / Случайное значение.
         """
         ...
 
     @abstractmethod
     def rand_int(self, rand: Optional[random.Random] = None) -> int:
-        """
-        Returns a random int in the interval boundary according to the distribution of the class
+        """Return a random integer within the interval.
 
-        :param rand: object for generating random numbers
-        :return kind: the random int
+        Возвращает случайное целое число в пределах интервала.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` for the
+                default. / Экземпляр генератора или ``None`` по умолчанию.
+
+        Returns:
+            int: Random value. / Случайное значение.
         """
         ...
 
 
 @dataclass(frozen=True)
 class IntervalUniform(Interval):
-    """
-    Implementation for uniform distribution
+    """Interval with a uniform distribution.
 
-    :param min_val: left border for the interval
-    :param max_val: right  border for the interval
-    :param rand: object for generating random numbers with, if you want to use a randomizer with a determined seed
+    Интервал с равномерным распределением.
+
+    Attributes:
+        min_val (float): Left boundary. / Левая граница.
+        max_val (float): Right boundary. / Правая граница.
+        rand (Random | None): Random generator. /
+            Генератор случайных чисел.
     """
+
     min_val: float
     max_val: float
     rand: Optional[Random] = Random()
 
     def rand_float(self, rand: Optional[random.Random] = None) -> float:
-        """
-        Returns a random float in the interval boundary according to the distribution of the class
+        """Generate a random float with a uniform distribution.
 
-        :param rand: object for generating random numbers, if you want to use a randomizer with a determined seed
-        :return kind: the random float
+        Сгенерировать случайное число с плавающей точкой при равномерном
+        распределении.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` to use
+                internal. / Экземпляр генератора или ``None`` для внутреннего
+                использования.
+
+        Returns:
+            float: Random value. / Случайное значение.
         """
         rand = rand or self.rand
         return rand.uniform(self.min_val, self.max_val)
 
     def rand_int(self, rand: Optional[random.Random] = None) -> int:
-        """
-        Returns a random int in the interval boundary according to the distribution of the class
+        """Generate a random integer with a uniform distribution.
 
-        :param rand: object for generating random numbers, if you want to use a randomizer with a determined seed
-        :return kind: the random int
+        Сгенерировать случайное целое число при равномерном распределении.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` to use
+                internal. / Экземпляр генератора или ``None`` для внутреннего
+                использования.
+
+        Returns:
+            int: Random value. / Случайное значение.
         """
         rand = rand or self.rand
         value = round(rand.uniform(self.min_val, self.max_val))
@@ -82,14 +115,17 @@ class IntervalUniform(Interval):
 
 @dataclass(frozen=True)
 class IntervalGaussian(Interval):
-    """
-    Implementation for Gaussian distribution
+    """Interval with a Gaussian distribution.
 
-    :param mean: mean for the distribution
-    :param sigma: variance for the distribution
-    :param min_val: left border for the interval
-    :param max_val: right  border for the interval
-    :param rand: object for generating random numbers with, if you want to use a randomizer with a determined seed
+    Интервал с нормальным распределением.
+
+    Attributes:
+        mean (float): Distribution mean. / Матожидание распределения.
+        sigma (float): Distribution variance. / Дисперсия распределения.
+        min_val (float | None): Left boundary. / Левая граница.
+        max_val (float | None): Right boundary. / Правая граница.
+        rand (Random | None): Random generator. /
+            Генератор случайных чисел.
     """
 
     mean: float
@@ -99,11 +135,18 @@ class IntervalGaussian(Interval):
     rand: Optional[Random] = Random()
 
     def rand_float(self, rand: Optional[random.Random] = None) -> float:
-        """
-        Returns a random float in the interval boundary according to the distribution of the class
+        """Generate a Gaussian-distributed float within bounds.
 
-        :param rand: object for generating random numbers
-        :return kind: the random float
+        Сгенерировать число с плавающей точкой по нормальному распределению в
+        заданных границах.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` to use
+                internal. / Экземпляр генератора или ``None`` для внутреннего
+                использования.
+
+        Returns:
+            float: Random value. / Случайное значение.
         """
         rand = rand or self.rand
         value = rand.gauss(self.mean, self.sigma)
@@ -111,13 +154,19 @@ class IntervalGaussian(Interval):
         value = min(value, self.max_val)
         return value
 
-
     def rand_int(self, rand: Optional[random.Random] = None) -> int:
-        """
-        Returns a random int in the interval boundary according to the distribution of the class
+        """Generate a Gaussian-distributed integer within bounds.
 
-        :param rand: object for generating random numbers
-        :return kind: the random int
+        Сгенерировать целое число по нормальному распределению в заданных
+        границах.
+
+        Args:
+            rand (random.Random | None): Generator instance or ``None`` to use
+                internal. / Экземпляр генератора или ``None`` для внутреннего
+                использования.
+
+        Returns:
+            int: Random value. / Случайное значение.
         """
         rand = rand or self.rand
         value = round(rand.gauss(self.mean, self.sigma))

--- a/sampo/schemas/landscape_graph.py
+++ b/sampo/schemas/landscape_graph.py
@@ -1,19 +1,35 @@
+"""Graph structures for a project's physical landscape.
+
+Графовые структуры физического ландшафта проекта.
+"""
+
 import uuid
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import numpy as np
 
 from sampo.schemas.exceptions import NoAvailableResources
 
+if TYPE_CHECKING:
+    from sampo.schemas.graph import GraphNode
+
 
 @dataclass
 class LandEdge:
+    """Connection between two nodes of the transport graph.
+
+    Связь между двумя узлами транспортного графа.
+
+    Attributes:
+        id (str): Edge identifier. / Идентификатор ребра.
+        start (LandGraphNode): Start node. / Начальный узел.
+        finish (LandGraphNode): Finish node. / Конечный узел.
+        weight (float): Distance or cost. / Длина или стоимость.
+        bandwidth (int): Capacity of the edge. / Пропускная способность.
     """
-    A representation of the connection between two vertices of a transport graph
-    (e.x., the edge between platform and warehouse)
-    """
+
     id: str
     start: 'LandGraphNode'
     finish: 'LandGraphNode'
@@ -22,10 +38,19 @@ class LandEdge:
 
 
 class ResourceStorageUnit:
+    """Storage for materials at a landscape node.
+
+    Хранилище материалов в узле ландшафта.
+    """
+
     def __init__(self, capacity: dict[str, int] | None = None):
-        """
-        Represents the resource storage of a land graph node
-        :param capacity: list of the maximum values of each material
+        """Initialize storage with capacity limits.
+
+        Инициализирует хранилище с ограничениями по ёмкости.
+
+        Args:
+            capacity (dict[str, int] | None): Maximum quantities for each
+                material. / Максимальные количества материалов.
         """
         if capacity is None:
             capacity = {}
@@ -37,18 +62,30 @@ class ResourceStorageUnit:
 
 
 class LandGraphNode:
+    """Participant of the landscape transport network.
+
+    Участник транспортной сети ландшафта.
+    """
+
     def __init__(self,
                  id: str = str(uuid.uuid4()),
                  name: str = 'platform',
                  resource_storage_unit: ResourceStorageUnit = ResourceStorageUnit(),
                  neighbour_nodes: list[tuple['LandGraphNode', float, int]] | None = None,
                  works: list['GraphNode'] | Any = None):
-        """
-        Represents the participant of landscape transport network
+        """Create a new landscape node.
 
-        :param neighbour_nodes: parent nodes list that saves parent itself and the weight of edge
-        :param resource_storage_unit: object that saves info about the resources in the current node
-        (in other words platform)
+        Создаёт новый узел ландшафта.
+
+        Args:
+            id (str): Node identifier. / Идентификатор узла.
+            name (str): Node name. / Имя узла.
+            resource_storage_unit (ResourceStorageUnit): Storage unit. /
+                Хранилище ресурсов.
+            neighbour_nodes (list[tuple[LandGraphNode, float, int]] | None):
+                Initial neighbours. / Начальные соседи.
+            works (list[GraphNode] | Any | None): Works located at node. /
+                Работы, расположенные в узле.
         """
         self.id = id
         self.name = name
@@ -97,8 +134,14 @@ class LandGraphNode:
             self._roads.append(LandEdge(road_id, self, neighbour, length, bandwidth))
             neighbour._roads.append(LandEdge(road_id, neighbour, self, length, bandwidth))
 
+
 @dataclass
 class LandGraph:
+    """Graph describing landscape connectivity.
+
+    Граф, описывающий связность ландшафта.
+    """
+
     nodes: list[LandGraphNode] = None
     adj_matrix: np.array = None
     node2ind: dict[LandGraphNode, int] = None
@@ -130,6 +173,10 @@ class LandGraph:
         return roads
 
     def _to_adj_matrix(self) -> tuple[np.array, dict[LandGraphNode, int], dict[str, int]]:
+        """Build adjacency matrix for current landscape graph.
+
+        Построить матрицу смежности для текущего ландшафтного графа.
+        """
         node2ind: dict[LandGraphNode, int] = {
             v: i for i, v in enumerate(self.nodes)
         }


### PR DESCRIPTION
## Summary
- add English and Russian module docstrings for graph, interval, landscape, and landscape_graph schemas
- document classes and functions in Google style with bilingual text

## Testing
- `flake8 --max-line-length=160 sampo/schemas/graph.py sampo/schemas/interval.py sampo/schemas/landscape.py sampo/schemas/landscape_graph.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e74fbe44832eab6ef46306b4ba1f