### PR TITLE
docs: add API package overview

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,6 @@
+1. Explore repository structure to understand context.
+2. Review `sampo/api/genetic_api.py` to identify main classes and their roles.
+3. Draft a bilingual summary (English then Russian) describing the API package and classes.
+4. Save summary in `sampo/api/README` (without extension), adhering to PEP 8 and Google Python Style recommendations.
+5. Run `pytest` to ensure project tests pass after documentation addition.
+6. Commit `plan.md` and `sampo/api/README` to the repository.

--- a/sampo/api/README
+++ b/sampo/api/README
@@ -1,0 +1,21 @@
+API Package Overview
+====================
+
+English
+-------
+The `sampo.api` package provides basic building blocks for genetic algorithm scheduling. The `const` module defines the stage separator `STAGE_SEP`, used when labeling stage identifiers in composite names. The `genetic_api` module introduces several core abstractions:
+
+- `ChromosomeType`: a tuple holding arrays, schedule specification, and auxiliary data for genetic computations.
+- `ScheduleGenerationScheme`: an enumeration of generation modes with `Parallel` and `Serial` strategies.
+- `FitnessFunction`: an abstract base class that requires an `evaluate` method returning a fitness score; lower values indicate better schedules.
+- `Individual`: a list-based container for chromosomes coupled with a customizable fitness object; the `prepare` helper returns a constructor suitable for genetic algorithms.
+
+Русский
+-------
+Пакет `sampo.api` предоставляет основные элементы для планирования на основе генетических алгоритмов. Модуль `const` определяет разделитель этапов `STAGE_SEP`, используемый при маркировке идентификаторов этапов в составных именах. Модуль `genetic_api` вводит несколько ключевых абстракций:
+
+- `ChromosomeType`: кортеж, содержащий массивы, спецификацию расписания и вспомогательные данные для генетических вычислений.
+- `ScheduleGenerationScheme`: перечисление режимов генерации с стратегиями `Parallel` и `Serial`.
+- `FitnessFunction`: абстрактный базовый класс, требующий метода `evaluate`, возвращающего значение приспособленности; меньшие значения обозначают лучшие расписания.
+- `Individual`: контейнер на основе списка для хромосом с настраиваемым объектом приспособленности; вспомогательный метод `prepare` возвращает конструктор, пригодный для генетических алгоритмов.
+


### PR DESCRIPTION
## Summary
- document API package structure and genetic algorithm interfaces
- provide English and Russian descriptions of core classes

## Testing
- `pytest tests/schedule_object_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8008e718c832eb3dd947c7e51d13c