### PR TITLE
Add runnable scripts for advanced guide examples

### DIFF
--- a/docs/source/guidebook/advanced/scripts/run_algorithms_examples.py
+++ b/docs/source/guidebook/advanced/scripts/run_algorithms_examples.py
@@ -1,0 +1,118 @@
+"""Run advanced algorithms documentation examples. Запустить примеры из раздела об алгоритмах."""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Iterable
+from uuid import uuid4
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.scheduler.genetic import GeneticScheduler
+from sampo.scheduler.heft import HEFTBetweenScheduler, HEFTScheduler
+from sampo.scheduler.topological import TopologicalScheduler
+from sampo.schemas.contractor import Contractor
+from sampo.schemas.resources import Worker
+from sampo.schemas.time import Time
+from sampo.schemas.works import WorkUnit
+
+try:
+    from sampo.scheduler.multi_agency.block_generator import (
+        SyntheticBlockGraphType,
+        generate_blocks,
+    )
+    from sampo.scheduler.multi_agency.multi_agency import Agent, StochasticManager
+    MULTI_AGENCY_AVAILABLE = True
+except ModuleNotFoundError:
+    MULTI_AGENCY_AVAILABLE = False
+
+
+def _universal_contractor(work_units: Iterable[WorkUnit]) -> list[Contractor]:
+    """Create a contractor that covers every worker requirement. Создать подрядчика для всех требований."""
+    kinds = {req.kind for unit in work_units for req in unit.worker_reqs}
+    contractor_id = str(uuid4())
+    workers = {
+        kind: Worker(str(uuid4()), kind, 50, contractor_id=contractor_id)
+        for kind in kinds
+    }
+    return [Contractor(id=contractor_id, name="Universal", workers=workers, equipments={})]
+
+
+def run_single_graph_examples(seed: int = 231) -> None:
+    """Execute heuristic and genetic scheduling samples. Выполнить примеры эвристик и генетики."""
+    synth = SimpleSynthetic(seed)
+    work_graph = synth.work_graph(bottom_border=12, top_border=16)
+    contractors = _universal_contractor(node.work_unit for node in work_graph.nodes)
+
+    schedulers = [
+        ("HEFT", HEFTScheduler()),
+        ("HEFTBetween", HEFTBetweenScheduler()),
+        ("Topological", TopologicalScheduler()),
+        (
+            "Genetic",
+            GeneticScheduler(
+                number_of_generation=5,
+                size_of_population=20,
+                mutate_order=0.2,
+                mutate_resources=0.2,
+            ),
+        ),
+    ]
+
+    for label, scheduler in schedulers:
+        schedule = scheduler.schedule(work_graph, contractors)[0]
+        assert schedule.execution_time > Time(0), f"{label} produced non-positive makespan"
+
+
+def run_multi_agent_examples(seed: int = 231) -> None:
+    """Execute multi-agent auction and block scheduling. Выполнить аукцион и блочное планирование."""
+    if not MULTI_AGENCY_AVAILABLE:
+        print("Skipping multi-agent examples due to missing multi-agency dependencies.")
+        return
+
+    synth = SimpleSynthetic(seed)
+    work_graph = synth.work_graph(bottom_border=8, top_border=10)
+    contractors = _universal_contractor(node.work_unit for node in work_graph.nodes)
+
+    agents = [
+        Agent("HEFT", HEFTScheduler(), contractors),
+        Agent("Topological", TopologicalScheduler(), contractors),
+    ]
+    manager = StochasticManager(agents)
+    start_time, end_time, schedule, winner = manager.run_auction(work_graph)
+    assert winner.name in {"HEFT", "Topological"}
+    assert end_time > start_time >= Time(0)
+    assert schedule.execution_time == end_time - start_time
+
+    random_source = Random(seed)
+    block_graph = generate_blocks(
+        SyntheticBlockGraphType.RANDOM,
+        n_blocks=3,
+        type_prop=[1, 1, 1],
+        count_supplier=lambda _: (5, 8),
+        edge_prob=0.4,
+        rand=random_source,
+    )
+
+    contractor_a = synth.contractor(20)
+    contractor_b = synth.contractor(20)
+
+    block_agents = [
+        Agent("HEFT", HEFTScheduler(), [contractor_a]),
+        Agent("Topo", TopologicalScheduler(), [contractor_b]),
+    ]
+    block_manager = StochasticManager(block_agents)
+    scheduled_blocks = block_manager.manage_blocks(block_graph)
+    assert scheduled_blocks, "Block scheduling did not produce any blocks"
+    for block in scheduled_blocks.values():
+        assert block.end_time > block.start_time
+        assert block.schedule.execution_time == block.end_time - block.start_time
+
+
+def main() -> None:
+    """Run all algorithm documentation examples. Выполнить все примеры из документации по алгоритмам."""
+    run_single_graph_examples()
+    run_multi_agent_examples()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guidebook/advanced/scripts/run_connections_examples.py
+++ b/docs/source/guidebook/advanced/scripts/run_connections_examples.py
@@ -1,0 +1,39 @@
+"""Run advanced connections documentation examples. Запустить примеры из раздела о связях."""
+
+from __future__ import annotations
+
+from sampo.schemas.graph import EdgeType, GraphNode, WorkGraph
+from sampo.schemas.works import WorkUnit
+
+
+def build_connection_demo() -> WorkGraph:
+    """Construct a graph demonstrating edge types. Построить граф для демонстрации типов связей."""
+    work_a = WorkUnit(id="A", name="Pour concrete", is_service_unit=False)
+    work_b = WorkUnit(id="B", name="Bricklaying", is_service_unit=False)
+    work_c = WorkUnit(id="C", name="Drilling", is_service_unit=False)
+    work_d = WorkUnit(id="D", name="Anchoring", is_service_unit=False)
+    work_e = WorkUnit(id="E", name="Monitoring start", is_service_unit=False)
+
+    node_a = GraphNode(work_a, [])
+    node_b = GraphNode(work_b, [(node_a, 3, EdgeType.LagFinishStart)])
+    node_c = GraphNode(work_c, [(node_b, 0, EdgeType.InseparableFinishStart)])
+    node_d = GraphNode(work_d, [(node_c, 0, EdgeType.InseparableFinishStart)])
+    node_e = GraphNode(work_e, [(node_a, 0, EdgeType.StartStart)])
+
+    work_graph = WorkGraph.from_nodes([node_a, node_b, node_c, node_d, node_e])
+    assert node_b.parents[0] == node_a
+    assert node_c.inseparable_parent == node_b
+    assert node_b.inseparable_son == node_c
+    assert node_a not in node_e.parents_set
+    assert any(edge.type == EdgeType.LagFinishStart for edge in node_b.edges_to)
+    assert node_a in node_e.neighbors
+    return work_graph
+
+
+def main() -> None:
+    """Run connections documentation examples. Выполнить примеры из документации по связям."""
+    build_connection_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guidebook/advanced/scripts/run_contractors_examples.py
+++ b/docs/source/guidebook/advanced/scripts/run_contractors_examples.py
@@ -1,0 +1,65 @@
+"""Run advanced contractor documentation examples. Запустить примеры из раздела о подрядчиках."""
+
+from __future__ import annotations
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.generator.environment.contractor_by_wg import (
+    ContractorGenerationMethod,
+    get_contractor_by_wg,
+)
+from sampo.schemas.contractor import Contractor
+from sampo.schemas.interval import IntervalGaussian
+from sampo.schemas.resources import Worker
+
+
+def build_manual_contractor() -> Contractor:
+    """Create a manual contractor definition. Создать подрядчика вручную."""
+    workers = {
+        "driver": Worker(
+            id="w1",
+            name="driver",
+            count=8,
+            productivity=IntervalGaussian(1.0, 0.1, 0.5, 1.5),
+        ),
+        "fitter": Worker(
+            id="w2",
+            name="fitter",
+            count=6,
+            productivity=IntervalGaussian(1.2, 0.1, 0.8, 1.6),
+        ),
+    }
+    contractor = Contractor(id="c1", name="Contractor A", workers=workers)
+    assert set(contractor.workers) == {"driver", "fitter"}
+    return contractor
+
+
+def build_synthetic_contractor(seed: int = 456) -> Contractor:
+    """Generate a contractor with SimpleSynthetic. Сгенерировать подрядчика через SimpleSynthetic."""
+    synth = SimpleSynthetic(seed)
+    contractor = synth.contractor(pack_worker_count=10)
+    assert contractor.workers, "Synthetic contractor must include workers"
+    return contractor
+
+
+def build_contractor_from_wg() -> Contractor:
+    """Create contractor based on WorkGraph requirements. Создать подрядчика по требованиям WorkGraph."""
+    synth = SimpleSynthetic(321)
+    work_graph = synth.work_graph(bottom_border=5, top_border=7)
+    contractor = get_contractor_by_wg(
+        work_graph,
+        scaler=1.0,
+        method=ContractorGenerationMethod.AVG,
+    )
+    assert contractor.workers, "Generated contractor must provide workers"
+    return contractor
+
+
+def main() -> None:
+    """Run contractor documentation examples. Выполнить примеры из документации о подрядчиках."""
+    build_manual_contractor()
+    build_synthetic_contractor()
+    build_contractor_from_wg()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guidebook/advanced/scripts/run_index_validation.py
+++ b/docs/source/guidebook/advanced/scripts/run_index_validation.py
@@ -1,0 +1,45 @@
+"""Validate the advanced guide index. Проверить индекс раздела advanced."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def extract_toctree_entries(index_path: Path) -> list[str]:
+    """Parse toctree entries from the index file. Извлечь элементы toctree из файла индекса."""
+    entries: list[str] = []
+    inside = False
+    for raw_line in index_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("```{toctree}"):
+            inside = True
+            continue
+        if not inside:
+            continue
+        if line == "```":
+            break
+        if not line or ":" in line:
+            continue
+        entries.append(line)
+    return entries
+
+
+def validate_entries() -> None:
+    """Ensure index references every documentation page. Убедиться, что индекс ссылается на все страницы."""
+    advanced_dir = Path(__file__).resolve().parents[1]
+    index_path = advanced_dir / "index.md"
+    assert index_path.exists(), "index.md is missing"
+    entries = extract_toctree_entries(index_path)
+    assert entries, "No entries parsed from index.md"
+    for entry in entries:
+        target = advanced_dir / f"{entry}.md"
+        assert target.exists(), f"Missing documentation file for {entry}"
+
+
+def main() -> None:
+    """Run index validation. Выполнить проверку индекса."""
+    validate_entries()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guidebook/advanced/scripts/run_scheduling_examples.py
+++ b/docs/source/guidebook/advanced/scripts/run_scheduling_examples.py
@@ -1,0 +1,48 @@
+"""Run advanced scheduling documentation examples. Запустить примеры из раздела о планировании."""
+
+from __future__ import annotations
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.pipeline import SchedulingPipeline
+from sampo.scheduler.genetic import GeneticScheduler
+from sampo.scheduler.heft.base import HEFTScheduler
+from sampo.schemas.time import Time
+
+
+def build_scheduling_inputs(seed: int = 789):
+    """Prepare a small WorkGraph and contractors. Подготовить небольшой WorkGraph и подрядчиков."""
+    synth = SimpleSynthetic(seed)
+    work_graph = synth.work_graph(bottom_border=6, top_border=8)
+    contractor = synth.contractor(pack_worker_count=15)
+    return work_graph, [contractor]
+
+
+def run_direct_scheduler_example() -> None:
+    """Run a HEFT scheduler directly. Запустить планировщик HEFT напрямую."""
+    work_graph, contractors = build_scheduling_inputs()
+    scheduler = HEFTScheduler()
+    schedule = scheduler.schedule(work_graph, contractors)[0]
+    assert schedule.execution_time > Time(0)
+
+
+def run_pipeline_scheduler_example(tmp_csv: str) -> None:
+    """Run the pipeline-based scheduling example. Запустить пример планирования через конвейер."""
+    result = (
+        SchedulingPipeline.create()
+        .wg(tmp_csv, sep=";", all_connections=True)
+        .schedule(GeneticScheduler(number_of_generation=3, size_of_population=10))
+        .finish()[0]
+    )
+    assert result.schedule.execution_time > Time(0)
+    dataframe = result.schedule.merged_stages_datetime_df(offset="2025-01-01")
+    assert not dataframe.empty
+
+
+def main() -> None:
+    """Run scheduling documentation examples. Выполнить примеры из документации по планированию."""
+    run_direct_scheduler_example()
+    run_pipeline_scheduler_example("tests/parser/test_wg.csv")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guidebook/advanced/scripts/run_work_graph_examples.py
+++ b/docs/source/guidebook/advanced/scripts/run_work_graph_examples.py
@@ -1,0 +1,89 @@
+"""Run advanced WorkGraph documentation examples. Запустить примеры из раздела о WorkGraph."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.generator.pipeline import SyntheticGraphType
+from sampo.pipeline import SchedulingPipeline
+from sampo.pipeline.lag_optimization import LagOptimizationStrategy
+from sampo.scheduler.heft import HEFTScheduler
+from sampo.schemas.graph import EdgeType, GraphNode, WorkGraph
+from sampo.schemas.requirements import WorkerReq
+from sampo.schemas.time import Time
+from sampo.schemas.works import WorkUnit
+
+
+def run_synthetic_example(seed: int = 123) -> WorkGraph:
+    """Generate a synthetic WorkGraph. Сгенерировать синтетический WorkGraph."""
+    synth = SimpleSynthetic(seed)
+    work_graph = synth.work_graph(
+        mode=SyntheticGraphType.GENERAL,
+        cluster_counts=3,
+        bottom_border=6,
+        top_border=10,
+    )
+    assert work_graph.vertex_count > 0
+    return work_graph
+
+
+def run_csv_pipeline_example() -> WorkGraph:
+    """Load a WorkGraph from CSV via pipeline. Загрузить WorkGraph из CSV через конвейер."""
+    csv_path = Path("tests/parser/test_wg.csv")
+    assert csv_path.exists(), "CSV example is missing"
+    project = (
+        SchedulingPipeline.create()
+        .wg(wg=str(csv_path), sep=";", all_connections=True)
+        .lag_optimize(LagOptimizationStrategy.TRUE)
+        .schedule(HEFTScheduler())
+        .finish()[0]
+    )
+    assert project.schedule.execution_time > Time(0)
+    assert project.wg.vertex_count > 0
+    return project.wg
+
+
+def run_manual_nodes_example() -> WorkGraph:
+    """Assemble WorkGraph from custom nodes. Собрать WorkGraph из пользовательских узлов."""
+    work_a = WorkUnit(
+        id="A",
+        name="Task A",
+        worker_reqs=[
+            WorkerReq(kind="general", volume=Time(10), min_count=1, max_count=2)
+        ],
+        volume=1.0,
+        is_service_unit=False,
+    )
+    work_b = WorkUnit(
+        id="B",
+        name="Task B",
+        worker_reqs=[],
+        volume=1.0,
+        is_service_unit=False,
+    )
+    work_c = WorkUnit(
+        id="C",
+        name="Task C",
+        worker_reqs=[],
+        volume=1.0,
+        is_service_unit=False,
+    )
+
+    node_a = GraphNode(work_a, [])
+    node_b = GraphNode(work_b, [(node_a, 0, EdgeType.FinishStart)])
+    node_c = GraphNode(work_c, [(node_b, 0, EdgeType.FinishStart)])
+    work_graph = WorkGraph.from_nodes([node_a, node_b, node_c])
+    assert work_graph.vertex_count == 5  # start + finish + 3 works
+    return work_graph
+
+
+def main() -> None:
+    """Run all WorkGraph documentation examples. Выполнить все примеры из документации по WorkGraph."""
+    run_synthetic_example()
+    run_csv_pipeline_example()
+    run_manual_nodes_example()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add executable Python scripts that mirror each advanced guide documentation example
- cover WorkGraph, contractors, connections, scheduling, algorithms, and index references with assertions for correctness
- gracefully skip multi-agent demonstrations when optional dependencies such as torch are unavailable

## Testing
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_algorithms_examples.py
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_work_graph_examples.py
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_connections_examples.py
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_contractors_examples.py
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_scheduling_examples.py
- PYTHONPATH=. python docs/source/guidebook/advanced/scripts/run_index_validation.py


------
https://chatgpt.com/codex/tasks/task_e_68d99d3f0920832e98df1e9c51e76d38