### PR TITLE
Add runnable demos for advanced documentation

### DIFF
--- a/examples/advanced/algorithms_demo.py
+++ b/examples/advanced/algorithms_demo.py
@@ -1,0 +1,132 @@
+"""Run advanced scheduling algorithm demonstrations.
+Запуск расширенных демонстраций алгоритмов планирования."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from random import Random
+from uuid import uuid4
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.scheduler.genetic import GeneticScheduler
+from sampo.scheduler.heft import HEFTScheduler
+from sampo.scheduler.topological import TopologicalScheduler
+from sampo.schemas.contractor import Contractor
+from sampo.schemas.graph import WorkGraph
+from sampo.schemas.resources import Worker
+
+
+def _run_scheduler_batch(work_graph: WorkGraph, contractors: list[Contractor]) -> None:
+    """Execute several schedulers on the same dataset and print makespans.
+    Выполнить несколько планировщиков на одном наборе данных и вывести длительности."""
+
+    schedulers = (
+        HEFTScheduler(),
+        TopologicalScheduler(),
+        GeneticScheduler(
+            number_of_generation=5,
+            size_of_population=15,
+            mutate_order=0.2,
+            mutate_resources=0.2,
+            seed=123,
+        ),
+    )
+    for scheduler in schedulers:
+        schedule, *_ = scheduler.schedule(work_graph, contractors)
+        print(f"{scheduler.scheduler_type} makespan: {schedule.execution_time}")
+
+
+def run_basic_algorithms(seed: int = 231) -> None:
+    """Demonstrate HEFT, Topological, and Genetic schedulers on a synthetic graph.
+    Продемонстрировать планировщики HEFT, Topological и Genetic на синтетическом графе."""
+
+    synthetic = SimpleSynthetic(seed)
+    work_graph = synthetic.work_graph(bottom_border=25, top_border=30)
+    contractor = synthetic.contractor(pack_worker_count=40)
+    _run_scheduler_batch(work_graph, [contractor])
+
+
+def run_multi_agent_auction(seed: int = 231) -> None:
+    """Run a stochastic auction between HEFT and Topological agents.
+    Запустить стохастический аукцион между агентами HEFT и Topological."""
+
+    try:
+        from sampo.scheduler.multi_agency.multi_agency import Agent, StochasticManager
+    except ModuleNotFoundError as error:  # pragma: no cover - environment dependent
+        print(f"Skipping multi-agent auction due to missing dependency: {error}")
+        return
+
+    synthetic = SimpleSynthetic(seed)
+    work_graph = synthetic.work_graph(bottom_border=30, top_border=35)
+
+    kinds = {req.kind for node in work_graph.nodes for req in node.work_unit.worker_reqs}
+    contractor_id = str(uuid4())
+    workers = {
+        kind: Worker(str(uuid4()), kind, 50, contractor_id=contractor_id)
+        for kind in kinds
+    }
+    contractors = [Contractor(id=contractor_id, name="Universal", workers=workers, equipments={})]
+
+    agents = [
+        Agent("HEFT", HEFTScheduler(), contractors),
+        Agent("Topological", TopologicalScheduler(), contractors),
+    ]
+    manager = StochasticManager(agents)
+    start, end, schedule, winner = manager.run_auction(work_graph)
+    print(f"Auction winner: {winner.name}, makespan: {end - start}, schedule id: {schedule.id}")
+
+
+def run_multi_agent_blocks(seed: int = 231) -> None:
+    """Manage a block graph with dedicated contractors for each agent.
+    Управлять графом блоков с выделенными подрядчиками для каждого агента."""
+
+    try:
+        from sampo.scheduler.multi_agency.block_generator import (
+            SyntheticBlockGraphType,
+            generate_blocks,
+        )
+        from sampo.scheduler.multi_agency.multi_agency import Agent, StochasticManager
+    except ModuleNotFoundError as error:  # pragma: no cover - environment dependent
+        print(f"Skipping block management due to missing dependency: {error}")
+        return
+
+    rand = Random(seed)
+    block_graph = generate_blocks(
+        SyntheticBlockGraphType.RANDOM,
+        n_blocks=4,
+        type_prop=[1, 1, 1],
+        count_supplier=lambda _: (10, 15),
+        edge_prob=0.3,
+        rand=rand,
+    )
+
+    synthetic = SimpleSynthetic(rand)
+    contractor_a = synthetic.contractor(pack_worker_count=40)
+    contractor_b = synthetic.contractor(pack_worker_count=40)
+
+    agents = [
+        Agent("HEFT", HEFTScheduler(), [contractor_a]),
+        Agent("Topo", TopologicalScheduler(), [contractor_b]),
+    ]
+    manager = StochasticManager(agents)
+    scheduled_blocks = manager.manage_blocks(block_graph)
+
+    print("Scheduled blocks summary:")
+    for block_id, sblock in scheduled_blocks.items():
+        print(
+            f"Block {block_id}: agent={sblock.agent.name}, "
+            f"start={sblock.start_time}, end={sblock.end_time}, duration={sblock.duration}"
+        )
+    makespan = max(sblock.end_time for sblock in scheduled_blocks.values())
+    print(f"Overall makespan: {makespan}")
+
+
+if __name__ == "__main__":
+    run_basic_algorithms()
+    run_multi_agent_auction()
+    run_multi_agent_blocks()

--- a/examples/advanced/connections_demo.py
+++ b/examples/advanced/connections_demo.py
@@ -1,0 +1,100 @@
+"""Validate connection examples from the advanced documentation.
+Проверить примеры связей из расширенной документации."""
+
+from __future__ import annotations
+
+import sys
+from csv import DictReader
+from io import StringIO
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sampo.schemas.graph import EdgeType, GraphNode, WorkGraph
+from sampo.schemas.requirements import WorkerReq
+from sampo.schemas.time import Time
+from sampo.schemas.works import WorkUnit
+
+
+def build_connection_graph() -> WorkGraph:
+    """Construct a work graph containing multiple edge types.
+    Построить граф работ, содержащий несколько типов связей."""
+
+    work_a = WorkUnit(
+        id="A",
+        name="Pour concrete",
+        worker_reqs=[WorkerReq("builder", Time(8), 2, 4)],
+        volume=1.0,
+    )
+    work_b = WorkUnit(id="B", name="Brickwork", volume=1.0)
+    work_c = WorkUnit(id="C", name="Drilling", volume=1.0)
+    work_d = WorkUnit(id="D", name="Anchoring", volume=1.0)
+    work_e = WorkUnit(id="E", name="Monitoring", volume=1.0)
+
+    node_a = GraphNode(work_a, [])
+    node_b = GraphNode(work_b, [(node_a, 3, EdgeType.LagFinishStart)])
+    node_c = GraphNode(work_c, [(node_b, 0, EdgeType.InseparableFinishStart)])
+    node_d = GraphNode(work_d, [(node_c, 0, EdgeType.InseparableFinishStart)])
+    node_e = GraphNode(work_e, [(node_a, 0, EdgeType.StartStart)])
+    work_f = WorkUnit(id="F", name="Documentation", volume=1.0)
+    node_f = GraphNode(work_f, [(node_a, 0, EdgeType.FinishFinish)])
+
+    return WorkGraph.from_nodes([node_a, node_b, node_c, node_d, node_e, node_f])
+
+
+def export_csv_logic(work_graph: WorkGraph) -> None:
+    """Show how CSV dependency rows could be produced.
+    Показать, как могут формироваться строки CSV с зависимостями."""
+
+    rows: list[str] = ["child_id,parent_id,type,lag"]
+    for node in work_graph.nodes:
+        for edge in node.edges_to:
+            if edge.start.work_unit.is_service_unit or edge.finish.work_unit.is_service_unit:
+                continue
+            rows.append(
+                f"{edge.finish.id},{edge.start.id},{edge.type.value},{int(edge.lag)}"
+            )
+    csv_output = "\n".join(rows)
+    print("CSV export preview:\n" + csv_output)
+
+
+def parse_csv_example() -> None:
+    """Parse the mini CSV snippet from the documentation.
+    Разобрать мини CSV из документации."""
+
+    data = """child_id,parent_id,type,lag\nB,A,FS,3\nC,B,IFS,0\nD,C,IFS,0\nE,A,SS,0\n"""
+    reader = DictReader(StringIO(data))
+    entries = list(reader)
+    print("Parsed CSV rows:")
+    for entry in entries:
+        print(entry)
+
+
+def summarize_graph(work_graph: WorkGraph) -> None:
+    """Print a summary of edge types and lags for validation.
+    Вывести сводку типов связей и лагов для проверки."""
+
+    print("Graph connections summary:")
+    for node in work_graph.nodes:
+        for edge in node.edges_to:
+            if edge.start.work_unit.is_service_unit or edge.finish.work_unit.is_service_unit:
+                continue
+            print(
+                f"{edge.start.id} -> {edge.finish.id}: type={edge.type.value}, lag={edge.lag}"
+            )
+
+
+def main() -> None:
+    """Run all connection verification routines.
+    Выполнить все проверки связей."""
+
+    work_graph = build_connection_graph()
+    summarize_graph(work_graph)
+    export_csv_logic(work_graph)
+    parse_csv_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/contractors_demo.py
+++ b/examples/advanced/contractors_demo.py
@@ -1,0 +1,102 @@
+"""Run contractor-related examples from the advanced documentation.
+Запустить примеры, связанные с подрядчиками, из расширенной документации."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.generator.environment.contractor_by_wg import (
+    ContractorGenerationMethod,
+    get_contractor_by_wg,
+)
+from sampo.schemas.contractor import Contractor
+from sampo.schemas.graph import GraphNode, WorkGraph
+from sampo.schemas.interval import IntervalGaussian
+from sampo.schemas.requirements import WorkerReq
+from sampo.schemas.resources import Worker
+from sampo.schemas.time import Time
+from sampo.schemas.works import WorkUnit
+
+
+def create_manual_contractor() -> Contractor:
+    """Create a contractor with explicit worker definitions.
+    Создать подрядчика с явным определением работников."""
+
+    contractor = Contractor(
+        workers={
+            "driver": Worker(
+                id="w1",
+                name="driver",
+                count=8,
+                productivity=IntervalGaussian(1.0, 0.1, 0.5, 1.5),
+            ),
+            "fitter": Worker(
+                id="w2",
+                name="fitter",
+                count=6,
+                productivity=IntervalGaussian(1.2, 0.1, 0.8, 1.6),
+            ),
+        },
+        id="c1",
+        name="Contractor A",
+    )
+    return contractor
+
+
+def create_synthetic_contractor(seed: int = 42) -> Contractor:
+    """Use SimpleSynthetic to create a contractor automatically.
+    Использовать SimpleSynthetic для автоматического создания подрядчика."""
+
+    synthetic = SimpleSynthetic(seed)
+    return synthetic.contractor(pack_worker_count=10)
+
+
+def create_contractor_from_work_graph() -> Contractor:
+    """Aggregate worker requirements from a small work graph.
+    Агрегировать требования к работникам из небольшого графа работ."""
+
+    work_a = WorkUnit(
+        id="A",
+        name="Excavation",
+        worker_reqs=[WorkerReq("digger", Time(4), 2, 3)],
+        volume=1.0,
+    )
+    work_b = WorkUnit(
+        id="B",
+        name="Reinforcement",
+        worker_reqs=[WorkerReq("fitter", Time(6), 2, 4)],
+        volume=1.0,
+    )
+    work_graph = WorkGraph.from_nodes([GraphNode(work_a, []), GraphNode(work_b, [])])
+    contractor = get_contractor_by_wg(
+        work_graph,
+        scaler=1.0,
+        method=ContractorGenerationMethod.AVG,
+    )
+    return contractor
+
+
+def main() -> None:
+    """Create contractors via all documented methods and show summaries.
+    Создать подрядчиков всеми описанными методами и показать сводку."""
+
+    manual = create_manual_contractor()
+    synthetic = create_synthetic_contractor()
+    by_wg = create_contractor_from_work_graph()
+
+    print("Manual contractor workers:")
+    for worker in manual.workers.values():
+        print(worker)
+
+    print("\nSynthetic contractor worker kinds:", list(synthetic.workers))
+    print("Generated from work graph worker kinds:", list(by_wg.workers))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/index_demo.py
+++ b/examples/advanced/index_demo.py
@@ -1,0 +1,55 @@
+"""Validate the advanced guide index structure against available topics.
+Проверить структуру оглавления расширенного руководства и наличие тем."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ADVANCED_DIR = Path("docs/source/guidebook/advanced")
+
+
+def extract_toctree_entries() -> list[str]:
+    """Read the toctree section and return listed entries.
+    Прочитать раздел toctree и вернуть перечисленные элементы."""
+
+    content = ADVANCED_DIR.joinpath("index.md").read_text(encoding="utf-8")
+    entries: list[str] = []
+    capture = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```{toctree}"):
+            capture = True
+            continue
+        if capture and stripped == "```":
+            break
+        if capture and stripped and not stripped.startswith(":") and not stripped.startswith("caption"):
+            entries.append(stripped)
+    return entries
+
+
+def verify_entries(entries: list[str]) -> None:
+    """Ensure every toctree entry has a corresponding documentation file.
+    Убедиться, что у каждого элемента toctree есть соответствующий файл документации."""
+
+    for entry in entries:
+        doc_path = ADVANCED_DIR.joinpath(f"{entry}.md")
+        exists = doc_path.exists()
+        print(f"Entry '{entry}' -> {doc_path} exists: {exists}")
+
+
+def main() -> None:
+    """Extract and verify toctree entries from the advanced index.
+    Извлечь и проверить элементы toctree из расширенного оглавления."""
+
+    entries = extract_toctree_entries()
+    print("Toctree entries:", entries)
+    verify_entries(entries)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/scheduling_demo.py
+++ b/examples/advanced/scheduling_demo.py
@@ -1,0 +1,68 @@
+"""Execute scheduling usage examples from the advanced guide.
+Выполнить примеры использования планировщика из расширенного руководства."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.pipeline import SchedulingPipeline
+from sampo.pipeline.lag_optimization import LagOptimizationStrategy
+from sampo.scheduler import GeneticScheduler
+from sampo.scheduler.heft import HEFTScheduler
+
+
+def run_direct_scheduler(seed: int = 21) -> None:
+    """Schedule a synthetic project with HEFT and show the makespan.
+    Спланировать синтетический проект с помощью HEFT и показать длительность."""
+
+    synthetic = SimpleSynthetic(seed)
+    work_graph = synthetic.work_graph(bottom_border=20, top_border=25)
+    contractor = synthetic.contractor(pack_worker_count=35)
+
+    scheduler = HEFTScheduler()
+    schedule, *_ = scheduler.schedule(work_graph, [contractor])
+    print("HEFT makespan:", schedule.execution_time)
+
+
+def run_pipeline_example() -> None:
+    """Run the scheduling pipeline with a genetic scheduler.
+    Запустить конвейер планирования с генетическим планировщиком."""
+
+    result = (
+        SchedulingPipeline.create()
+        .wg("tests/parser/test_wg.csv", sep=";", all_connections=True)
+        .lag_optimize(LagOptimizationStrategy.TRUE)
+        .schedule(
+            GeneticScheduler(
+                number_of_generation=3,
+                size_of_population=10,
+                mutate_order=0.1,
+                mutate_resources=0.1,
+                seed=123,
+            )
+        )
+        .finish()
+    )[0]
+
+    schedule = result.schedule
+    print("Pipeline makespan:", schedule.execution_time)
+    df = schedule.merged_stages_datetime_df("2025-01-01")
+    print(df.head())
+
+
+def main() -> None:
+    """Execute both scheduling demonstrations.
+    Выполнить обе демонстрации планирования."""
+
+    run_direct_scheduler()
+    run_pipeline_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advanced/work_graph_demo.py
+++ b/examples/advanced/work_graph_demo.py
@@ -1,0 +1,85 @@
+"""Reproduce WorkGraph creation examples from the advanced guide.
+Воспроизвести примеры создания WorkGraph из расширенного руководства."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sampo.generator.base import SimpleSynthetic
+from sampo.generator.pipeline import SyntheticGraphType
+from sampo.pipeline import SchedulingPipeline
+from sampo.pipeline.lag_optimization import LagOptimizationStrategy
+from sampo.scheduler.heft import HEFTScheduler
+from sampo.schemas.graph import EdgeType, GraphNode, WorkGraph
+from sampo.schemas.requirements import WorkerReq
+from sampo.schemas.time import Time
+from sampo.schemas.works import WorkUnit
+
+
+def generate_synthetic_graph() -> WorkGraph:
+    """Create a synthetic graph with the documented parameters.
+    Создать синтетический граф с параметрами из документации."""
+
+    synthetic = SimpleSynthetic()
+    return synthetic.work_graph(
+        mode=SyntheticGraphType.GENERAL,
+        cluster_counts=10,
+        bottom_border=100,
+        top_border=200,
+    )
+
+
+def load_graph_from_csv() -> WorkGraph:
+    """Load a graph through the scheduling pipeline to mimic CSV import.
+    Загрузить граф через конвейер планирования, имитируя импорт CSV."""
+
+    result = (
+        SchedulingPipeline.create()
+        .wg(wg="tests/parser/test_wg.csv", sep=";", all_connections=True)
+        .lag_optimize(LagOptimizationStrategy.TRUE)
+        .schedule(HEFTScheduler())
+        .finish()
+    )[0]
+    return result.wg
+
+
+def build_graph_programmatically() -> WorkGraph:
+    """Assemble a small graph manually with explicit dependencies.
+    Собрать небольшой граф вручную с явными зависимостями."""
+
+    wu_a = WorkUnit(
+        id="A",
+        name="Task A",
+        worker_reqs=[WorkerReq("general", Time(10), 2, 4)],
+        volume=1.0,
+        is_service_unit=False,
+    )
+    wu_b = WorkUnit(id="B", name="Task B", volume=1.0, is_service_unit=False)
+    wu_c = WorkUnit(id="C", name="Task C", volume=1.0, is_service_unit=False)
+
+    node_a = GraphNode(wu_a, [])
+    node_b = GraphNode(wu_b, [(node_a, 0, EdgeType.FinishStart)])
+    node_c = GraphNode(wu_c, [(node_b, 0, EdgeType.FinishStart)])
+    return WorkGraph.from_nodes([node_a, node_b, node_c])
+
+
+def main() -> None:
+    """Generate and summarize all WorkGraph examples.
+    Сгенерировать и описать все примеры WorkGraph."""
+
+    synthetic_graph = generate_synthetic_graph()
+    csv_graph = load_graph_from_csv()
+    manual_graph = build_graph_programmatically()
+
+    print("Synthetic graph vertices:", synthetic_graph.vertex_count)
+    print("CSV graph vertices:", csv_graph.vertex_count)
+    print("Manual graph vertices:", manual_graph.vertex_count)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add runnable Python demo scripts that exercise the advanced guidebook topics and keep docstrings bilingual
- include an index validation helper to ensure the advanced toctree references existing files

## Testing
- python examples/advanced/algorithms_demo.py
- python examples/advanced/connections_demo.py
- python examples/advanced/contractors_demo.py
- python examples/advanced/scheduling_demo.py
- python examples/advanced/work_graph_demo.py
- python examples/advanced/index_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68d99d3f0920832e98df1e9c51e76d38